### PR TITLE
Moved react and react-dom to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "lodash": "^3.10.1",
     "material-colors": "^1.0.0",
     "merge": "^1.2.0",
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0",
     "reactcss": "^0.3.2",
     "tinycolor2": "^1.1.2"
+  },
+  "peerDependencies": {
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "devDependencies": {
     "babel": "^5.8.21",


### PR DESCRIPTION
Moved react and react-dom to peerDependencies where they belong :wink: Got burned by the multiple-react-version issue when installing the latest@1.2.0.