### PR TITLE
Use modularized lodash isString method

### DIFF
--- a/modules/react-material-design/src/components/Link.js
+++ b/modules/react-material-design/src/components/Link.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react';
-import _ from 'lodash';
+import isString from 'lodash.isstring';
 
 class Link extends React.Component {
 
@@ -19,7 +19,7 @@ class Link extends React.Component {
   render() {
 
     var a;
-    if (_.isString(this.props.onClick)) {
+    if (isString(this.props.onClick)) {
       a = <a style={{ textDecoration: 'none' }} href={ this.props.onClick } target={ this.props.newTab && '_blank' }>{ this.props.children }</a>;
     } else {
       a = <a style={{ textDecoration: 'none' }} onClick={ this.handleClick }>{ this.props.children }</a>;

--- a/modules/react-material-design/src/components/Tabs.js
+++ b/modules/react-material-design/src/components/Tabs.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import ReactCSS from 'reactcss';
-import _ from 'lodash';
+import isString from 'lodash.isstring';
 
 import Tab from './Tab';
 import Link from './Link';
@@ -178,7 +178,7 @@ class Tabs extends ReactCSS.Component {
       var callback;
       var callbackValue;
       var newTab;
-      if (_.isString(tab)) {
+      if (isString(tab)) {
         label = tab;
         callback = null;
       } else {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "lodash.debounce": "^4.0.0",
     "lodash.isplainobject": "^4.0.0",
+    "lodash.isstring": "^4.0.0",
     "lodash.throttle": "^4.0.0",
     "material-colors": "^1.0.0",
     "merge": "^1.2.0",


### PR DESCRIPTION
### Summary
Fixes issue https://github.com/casesandberg/react-color/issues/79 by adding the lodash.isstring dependency and using it in the Tabs.js and Link.js files.

### Notes
Mention of the same error also appears in issue https://github.com/casesandberg/react-color/issues/78, but I'm not sure if it is related to the other problems mentioned there. I do not have any errors when using this change, but I was not able to build beforehand either. I recommend trying to repro https://github.com/casesandberg/react-color/issues/78 again after this fix is merged.

I published a public scoped package for testing under @dpwolfe/react-color as version 1.3.4-1 if anybody wants to try verifying with that.
