### PR TITLE
return early to avoid jest canvas context

### DIFF
--- a/lib/components/common/Checkboard.js
+++ b/lib/components/common/Checkboard.js
@@ -30,6 +30,7 @@ function renderCheckboard(c1, c2, size) {
   var canvas = document.createElement('canvas');
   canvas.width = canvas.height = size * 2;
   var ctx = canvas.getContext('2d');
+  if (!ctx) return null; // If no context can be found, return early.
   ctx.fillStyle = c1;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = c2;

--- a/modules/react-material-design/lib/components/Link.js
+++ b/modules/react-material-design/lib/components/Link.js
@@ -1,14 +1,14 @@
 'use strict';
 
+var _isString = require('lodash/lang/isString');
+
+var _isString2 = _interopRequireDefault(_isString);
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-var _isString = require('lodash/lang/isString');
-
-var _isString2 = _interopRequireDefault(_isString);
 
 var _react = require('react');
 

--- a/modules/react-material-design/lib/components/Tabs.js
+++ b/modules/react-material-design/lib/components/Tabs.js
@@ -1,5 +1,9 @@
 'use strict';
 
+var _isString = require('lodash/lang/isString');
+
+var _isString2 = _interopRequireDefault(_isString);
+
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -7,10 +11,6 @@ var _createClass = function () { function defineProperties(target, props) { for 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-var _isString = require('lodash/lang/isString');
-
-var _isString2 = _interopRequireDefault(_isString);
 
 var _react = require('react');
 

--- a/src/components/common/Checkboard.js
+++ b/src/components/common/Checkboard.js
@@ -10,6 +10,7 @@ function renderCheckboard(c1: string, c2: string, size: number): any {
   var canvas: any = document.createElement('canvas');
   canvas.width = canvas.height = size * 2;
   var ctx = canvas.getContext('2d');
+  if (!ctx) return null; // If no context can be found, return early.
   ctx.fillStyle = c1;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
   ctx.fillStyle = c2;


### PR DESCRIPTION
Thanks for the awesome react component! Just a quick issue/PR:

It's impossible to test `react-color` with Jest, because Jest sets up a `jsdom` `document` and `window`, but doing the following in Jest does not work:

```javascript
let canvas = document.createElement('canvas'); // works
let context = canvas.getContext('2d'); // breaks!!
```

So that means that at this line in our jest tests: (from react-color module)
https://github.com/casesandberg/react-color/blob/master/src/components/common/Checkboard.js#L9

We pass through OK, but we get here: (react-color module)
https://github.com/casesandberg/react-color/blob/master/src/components/common/Checkboard.js#L13

and `ctx` is undefined so everything breaks.

We do want it to be able to render this component in our Jest tests. By adding the following to Checkboard.js:

```javascript
if (!ctx) return null;
```

It works! It bails there and our tests can still continue on.

Please let me know if this is something worthwhile putting in, as if not I'm sure other may have issues testing this component with Jest!

I ran `gulp dist` after modifying that one line and a couple changes came up. Let me know if those changes are OK too!

Thanks!