### PR TITLE
Make Hue, Sat, and Alpha components respond to touch start

### DIFF
--- a/lib/components/common/Alpha.js
+++ b/lib/components/common/Alpha.js
@@ -137,7 +137,9 @@ var Alpha = exports.Alpha = function (_ReactCSS$Component) {
         _react2.default.createElement('div', { style: this.styles().gradient }),
         _react2.default.createElement(
           'div',
-          { style: this.styles().container, ref: 'container', onMouseDown: this.handleMouseDown, onTouchMove: this.handleChange },
+          { style: this.styles().container, ref: 'container', onMouseDown: this.handleMouseDown,
+            onTouchMove: this.handleChange,
+            onTouchStart: this.handleChange },
           _react2.default.createElement(
             'div',
             { style: this.styles().pointer, ref: 'pointer' },

--- a/lib/components/common/Hue.js
+++ b/lib/components/common/Hue.js
@@ -146,7 +146,9 @@ var Hue = exports.Hue = function (_ReactCSS$Component) {
         { style: this.styles().hue },
         _react2.default.createElement(
           'div',
-          { style: this.styles().container, ref: 'container', onMouseDown: this.handleMouseDown, onTouchMove: this.handleChange },
+          { style: this.styles().container, ref: 'container', onMouseDown: this.handleMouseDown,
+            onTouchMove: this.handleChange,
+            onTouchStart: this.handleChange },
           _react2.default.createElement(
             'div',
             { style: this.styles().pointer, ref: 'pointer' },

--- a/lib/components/common/Saturation.js
+++ b/lib/components/common/Saturation.js
@@ -130,7 +130,9 @@ var Saturation = exports.Saturation = function (_ReactCSS$Component) {
 
       return _react2.default.createElement(
         'div',
-        { style: this.styles().color, ref: 'container', onMouseDown: this.handleMouseDown, onTouchMove: this.handleChange },
+        { style: this.styles().color, ref: 'container', onMouseDown: this.handleMouseDown,
+          onTouchMove: this.handleChange,
+          onTouchStart: this.handleChange },
         _react2.default.createElement(
           'div',
           { style: this.styles().white },

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -100,7 +100,9 @@ export class Alpha extends ReactCSS.Component {
           <Checkboard />
         </div>
         <div is="gradient" />
-        <div is="container" ref="container" onMouseDown={ this.handleMouseDown } onTouchMove={ this.handleChange }>
+        <div is="container" ref="container" onMouseDown={ this.handleMouseDown }
+            onTouchMove={ this.handleChange }
+            onTouchStart={ this.handleChange }>
           <div is="pointer" ref="pointer">
             { pointer }
           </div>

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -113,7 +113,9 @@ export class Hue extends ReactCSS.Component {
 
     return (
       <div is="hue">
-        <div is="container" ref="container" onMouseDown={ this.handleMouseDown } onTouchMove={ this.handleChange }>
+        <div is="container" ref="container" onMouseDown={ this.handleMouseDown }
+            onTouchMove={ this.handleChange }
+            onTouchStart={ this.handleChange }>
           <div is="pointer" ref="pointer">
             { pointer }
           </div>

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -96,7 +96,9 @@ export class Saturation extends ReactCSS.Component {
     }
 
     return (
-      <div is="color" ref="container" onMouseDown={ this.handleMouseDown } onTouchMove={ this.handleChange }>
+      <div is="color" ref="container" onMouseDown={ this.handleMouseDown }
+          onTouchMove={ this.handleChange }
+          onTouchStart={ this.handleChange }>
         <div is="white">
           <div is="black" />
           <div is="pointer" ref="pointer">


### PR DESCRIPTION
This change allows you to directly tap select the desired value of the saturation field or sliders. Currently these components only update if you touch and drag around a little, making precise input difficult. Part work for #69 

Tested on an iPhone.