### PR TITLE
Fix sliderSwatches styles breaking on small widths

### DIFF
--- a/lib/components/slider/SliderSwatches.js
+++ b/lib/components/slider/SliderSwatches.js
@@ -47,12 +47,12 @@ var SliderSwatches = exports.SliderSwatches = function (_ReactCSS$Component) {
       return {
         'default': {
           swatches: {
-            marginRight: '-4px',
             marginTop: '20px'
           },
           swatch: {
-            width: '19.65%',
-            marginRight: '1px',
+            boxSizing: 'border-box',
+            width: '20%',
+            paddingRight: '1px',
             float: 'left'
           },
           clear: {

--- a/src/components/slider/SliderSwatches.js
+++ b/src/components/slider/SliderSwatches.js
@@ -17,12 +17,12 @@ export class SliderSwatches extends ReactCSS.Component {
     return {
       'default': {
         swatches: {
-          marginRight: '-4px',
           marginTop: '20px',
         },
         swatch: {
-          width: '19.65%',
-          marginRight: '1px',
+          boxSizing: 'border-box',
+          width: '20%',
+          paddingRight: '1px',
           float: 'left',
         },
         clear: {


### PR DESCRIPTION
The styles were not precise enough. Using padding instead of margin fixes that.