### PR TITLE
Correct name of Components referenced in docs

### DIFF
--- a/docs/documentation/04.02-helpers.md
+++ b/docs/documentation/04.02-helpers.md
@@ -56,7 +56,7 @@ Use Hue to display a slider to toggle the hue value. Make sure to wrap it in a d
 * **onChange** - Function callback. Make sure this calls the onChange function of the parent to make it change.
 * **direction** - Display direction of the slider. Horizontal by default.
 ```
-var { Alpha } = require('react-color/src/components/common');
+var { Hue } = require('react-color/src/components/common');
 
 <Hue
   {...this.props}
@@ -72,7 +72,7 @@ Use Saturation to display a saturation block that users can drag to change the v
 * **pointer** - Define a custom pointer component for the slider pointer.
 * **onChange** - Function callback. Make sure this calls the onChange function of the parent to make it change.
 ```
-var { Alpha } = require('react-color/src/components/common');
+var { Saturation } = require('react-color/src/components/common');
 
 <Saturation
   {...this.props}


### PR DESCRIPTION
Hey I noticed the `<Alpha />` component was incorrectly included in the docs for sections `Hue & Saturation` so I updated it 👍 