### PR TITLE
Why use z-index?

### DIFF
--- a/lib/components/chrome/Chrome.js
+++ b/lib/components/chrome/Chrome.js
@@ -103,7 +103,6 @@ var Chrome = exports.Chrome = function (_ReactCSS$Component) {
           },
           active: {
             Absolute: '0 0 0 0',
-            zIndex: 2,
             borderRadius: '8px',
             boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.1)',
             background: 'rgba(' + this.props.rgb.r + ', ' + this.props.rgb.g + ', ' + this.props.rgb.b + ', ' + this.props.rgb.a + ')'

--- a/lib/components/chrome/ChromeFields.js
+++ b/lib/components/chrome/ChromeFields.js
@@ -134,8 +134,7 @@ var ChromeFields = exports.ChromeFields = function (_ReactCSS$Component) {
             marginRight: '-4px',
             marginTop: '12px',
             cursor: 'pointer',
-            position: 'relative',
-            zIndex: '2'
+            position: 'relative'
           },
           iconHighlight: {
             position: 'absolute',

--- a/lib/components/common/Alpha.js
+++ b/lib/components/common/Alpha.js
@@ -101,12 +101,10 @@ var Alpha = exports.Alpha = function (_ReactCSS$Component) {
           },
           container: {
             position: 'relative',
-            zIndex: '2',
             height: '100%',
             margin: '0 3px'
           },
           pointer: {
-            zIndex: '2',
             position: 'absolute',
             left: this.props.rgb.a * 100 + '%'
           },

--- a/lib/components/common/Hue.js
+++ b/lib/components/common/Hue.js
@@ -115,7 +115,6 @@ var Hue = exports.Hue = function (_ReactCSS$Component) {
             height: '100%'
           },
           pointer: {
-            zIndex: '2',
             position: 'absolute',
             left: this.props.hsl.h * 100 / 360 + '%'
           },

--- a/lib/components/sketched/Sketch.js
+++ b/lib/components/sketched/Sketch.js
@@ -99,8 +99,7 @@ var Sketch = exports.Sketch = function (_ReactCSS$Component) {
             Absolute: '0 0 0 0',
             borderRadius: '2px',
             background: 'rgba(' + this.props.rgb.r + ', ' + this.props.rgb.g + ', ' + this.props.rgb.b + ', ' + this.props.rgb.a + ')',
-            boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.15), inset 0 0 4px rgba(0,0,0,.25)',
-            zIndex: '2'
+            boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.15), inset 0 0 4px rgba(0,0,0,.25)'
           },
           hue: {
             position: 'relative',

--- a/lib/components/sketched/Sketch.js
+++ b/lib/components/sketched/Sketch.js
@@ -155,8 +155,7 @@ var Sketch = exports.Sketch = function (_ReactCSS$Component) {
           _react2.default.createElement(
             'div',
             { style: this.styles().color },
-            _react2.default.createElement('div', { style: this.styles().activeColor }),
-            _react2.default.createElement(_common.Checkboard, null)
+            _react2.default.createElement(_common.Checkboard, null),_react2.default.createElement('div', { style: this.styles().activeColor })
           )
         ),
         _react2.default.createElement(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-color",
-  "version": "2.0.0-no-z-index",
+  "version": "2.0.0",
   "description": "A Collection of Color Pickers from Sketch, Photoshop, Chrome & more",
   "main": "lib/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-color",
-  "version": "2.0.0",
+  "version": "2.0.0-no-z-index",
   "description": "A Collection of Color Pickers from Sketch, Photoshop, Chrome & more",
   "main": "lib/index.js",
   "repository": {

--- a/src/components/chrome/Chrome.js
+++ b/src/components/chrome/Chrome.js
@@ -52,7 +52,6 @@ export class Chrome extends ReactCSS.Component {
         },
         active: {
           Absolute: '0 0 0 0',
-          zIndex: 2,
           borderRadius: '8px',
           boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.1)',
           background: 'rgba(' + this.props.rgb.r + ', ' + this.props.rgb.g + ', ' + this.props.rgb.b + ', ' + this.props.rgb.a + ')',

--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -39,8 +39,7 @@ export class ChromeFields extends ReactCSS.Component {
           marginRight: '-4px',
           marginTop: '12px',
           cursor: 'pointer',
-          position: 'relative',
-          zIndex: '2',
+          position: 'relative'
         },
         iconHighlight: {
           position: 'absolute',

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -28,12 +28,10 @@ export class Alpha extends ReactCSS.Component {
         },
         container: {
           position: 'relative',
-          zIndex: '2',
           height: '100%',
           margin: '0 3px',
         },
         pointer: {
-          zIndex: '2',
           position: 'absolute',
           left: this.props.rgb.a * 100 + '%',
         },

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -22,7 +22,6 @@ export class Hue extends ReactCSS.Component {
           height: '100%',
         },
         pointer: {
-          zIndex: '2',
           position: 'absolute',
           left: (this.props.hsl.h * 100) / 360 + '%',
         },

--- a/src/components/sketched/Sketch.js
+++ b/src/components/sketched/Sketch.js
@@ -51,8 +51,7 @@ export class Sketch extends ReactCSS.Component {
           Absolute: '0 0 0 0',
           borderRadius: '2px',
           background: 'rgba(' + this.props.rgb.r + ', ' + this.props.rgb.g + ', ' + this.props.rgb.b + ', ' + this.props.rgb.a + ')',
-          boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.15), inset 0 0 4px rgba(0,0,0,.25)',
-          zIndex: '2',
+          boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.15), inset 0 0 4px rgba(0,0,0,.25)'
         },
         hue: {
           position: 'relative',
@@ -98,8 +97,8 @@ export class Sketch extends ReactCSS.Component {
             </div>
           </div>
           <div is="color">
-            <div is="activeColor"/>
             <Checkboard />
+            <div is="activeColor"/>
           </div>
         </div>
         <div is="fields">


### PR DESCRIPTION
Hi, z-index applies to the whole document which is problematic when having an overlay layer on top of the color picker, the handles and the color square "shine" trough.