### PR TITLE
Depend on mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "html-loader": "^0.3.0",
     "jsx-loader": "^0.13.2",
     "lodash": "^4.6.0",
+    "mocha": "^2.4.5",
     "normalize.css": "^4.1.1",
     "react-addons-test-utils": "^15.0.0",
     "react-context": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "https://github.com/casesandberg/react-color/issues"
   },
   "scripts": {
-    "unit-test": "./node_modules/mocha/bin/mocha \"test/**/*.test.js\" --compilers js:babel-register",
+    "unit-test": "mocha \"test/**/*.test.js\" --compilers js:babel-register",
     "test": "npm run unit-test",
     "clean": "rm -rf lib && mkdir lib",
-    "lib": "npm run clean && cp -a src/. lib && node map-styles && ./node_modules/.bin/babel lib -d lib",
+    "lib": "npm run clean && cp -a src/. lib && node map-styles && babel lib -d lib",
     "docs": "node docs-server",
     "docs-dist": "node docs-dist"
   },


### PR DESCRIPTION
I'm currently unable to run tests on a clean pull of react-color (that is git clone, npm install, npm test), because `mocha` is not found:

```
> npm test

> react-color@2.1.0 test /home/brad/Projects/casesandberg/react-color
> npm run unit-test


> react-color@2.1.0 unit-test /home/brad/Projects/casesandberg/react-color
> ./node_modules/mocha/bin/mocha "test/**/*.test.js" --compilers js:babel-register

sh: 1: ./node_modules/mocha/bin/mocha: not found
```

A quick investigation revealed that `mocha` is not listed in the `devDependencies` for react-color, even though it's used in its test script.  Maybe it was inherited from another package in the past? To be honest, I'm not sure why tests are passing on CI prior to this change.

In any case, this change adds mocha as a dev-dependency so tests will run. This [won't affect consumers of the package](https://docs.npmjs.com/files/package.json#devdependencies). It also updates the npm scripts to stop using relative paths for mocha and babel, [because node_modules/.bin is implicitly added to the PATH in the scope of npm scripts](https://docs.npmjs.com/misc/scripts#path).