### PR TITLE
Remove lodash dev-dependency, since it's already a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "highlight.js": "^9.3.0",
     "html-loader": "^0.3.0",
     "jsx-loader": "^0.13.2",
-    "lodash": "^4.6.0",
     "normalize.css": "^4.1.1",
     "react-addons-test-utils": "^15.0.0",
     "react-context": "0.0.3",


### PR DESCRIPTION
I was seeing the following warning on `npm install`:

```
npm WARN package.json Dependency 'lodash' exists in both dependencies and devDependencies, using 'lodash@^4.0.1' from dependencies
```

Since it was ignoring the lodash entry in `devDependencies` we can just remove it.