### PR TITLE
Fix active color dot in Compact style

### DIFF
--- a/lib/components/compact/Compact.js
+++ b/lib/components/compact/Compact.js
@@ -99,7 +99,7 @@ var Compact = exports.Compact = function (_ReactCSS$Component) {
       if (this.props.colors) {
         for (var i = 0; i < this.props.colors.length; i++) {
           var color = this.props.colors[i];
-          colors.push(_react2.default.createElement(_CompactColor2.default, { key: color, color: color, active: color.replace('#', '').toLowerCase() == this.props.hex, onClick: this.handleChange }));
+          colors.push(_react2.default.createElement(_CompactColor2.default, { key: color, color: color, active: color.toLowerCase() == this.props.hex, onClick: this.handleChange }));
         }
       }
 

--- a/src/components/compact/Compact.js
+++ b/src/components/compact/Compact.js
@@ -50,7 +50,7 @@ export class Compact extends ReactCSS.Component {
     if (this.props.colors) {
       for (var i = 0; i < this.props.colors.length; i++) {
         var color = this.props.colors[i]
-        colors.push(<CompactColor key={ color } color={ color } active={ color.replace('#', '').toLowerCase() == this.props.hex } onClick={ this.handleChange } />)
+        colors.push(<CompactColor key={ color } color={ color } active={ color.toLowerCase() == this.props.hex } onClick={ this.handleChange } />)
       }
     }
 


### PR DESCRIPTION
I noticed that the active color's "dot" in the Compact-style picker wasn't showing - this fixes it.

Screenshot of the fixed component:
![image](https://cloud.githubusercontent.com/assets/903712/15473260/296b3ee8-20cd-11e6-98e1-5028c6be69c9.png)
