### PR TITLE
Updated doc examples to allow clicks within picker control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+.DS_Store

--- a/examples/Button.js
+++ b/examples/Button.js
@@ -26,14 +26,20 @@ class ButtonExample extends React.Component {
       top: '0px',
       right: '0px',
       bottom: '0px',
-      left: '0px',
+      left: '0px'
+    }
+    const wrapper = {
+      position: 'inherit',
+      zIndex: '100'
     }
     return (
       <div>
         <button onClick={ this.handleClick }>Pick Color</button>
         { this.state.displayColorPicker ? <div style={ popover }>
           <div style={ cover } onClick={ this.handleClose }/>
-          <ChromePicker />
+          <div style={ wrapper }>
+            <ChromePicker />
+          </div>
         </div> : null }
       </div>
     )

--- a/examples/Sketch.js
+++ b/examples/Sketch.js
@@ -41,8 +41,12 @@ class SketchExample extends ReactCSS.Component {
           top: '0px',
           right: '0px',
           bottom: '0px',
-          left: '0px',
+          left: '0px'
         },
+        wrapper: {
+          position: 'inherit',
+          zIndex: '100'
+        }
       },
     }
   }
@@ -67,7 +71,9 @@ class SketchExample extends ReactCSS.Component {
         </div>
         { this.state.displayColorPicker ? <div is="popover">
           <div is="cover" onClick={ this.handleClose }/>
-          <SketchPicker color={ this.state.color } onChange={ this.handleChange } />
+          <div is="wrapper">
+            <SketchPicker color={ this.state.color } onChange={ this.handleChange } />
+          </div>
         </div> : null }
 
       </div>

--- a/examples/button.md
+++ b/examples/button.md
@@ -29,12 +29,18 @@ class ButtonExample extends React.Component {
       bottom: '0px',
       left: '0px',
     }
+    const wrapper = {
+      position: 'inherit',
+      zIndex: '100'
+    }
     return (
       <div>
         <button onClick={ this.handleClick }>Pick Color</button>
         { this.state.displayColorPicker ? <div style={ popover }>
           <div style={ cover } onClick={ this.handleClose }/>
-          <ChromePicker />
+          <div style={ wrapper }>
+            <ChromePicker />
+          </div>
         </div> : null }
       </div>
     )

--- a/examples/sketch.md
+++ b/examples/sketch.md
@@ -42,8 +42,12 @@ class SketchExample extends ReactCSS.Component {
           top: '0px',
           right: '0px',
           bottom: '0px',
-          left: '0px',
+          left: '0px'
         },
+        wrapper: {
+          position: 'inherit',
+          zIndex: 100
+        }
       },
     }
   }
@@ -68,7 +72,9 @@ class SketchExample extends ReactCSS.Component {
         </div>
         { this.state.displayColorPicker ? <div is="popover">
           <div is="cover" onClick={ this.handleClose }/>
-          <SketchPicker color={ this.state.color } onChange={ this.handleChange } />
+          <div is"wrapper">
+            <SketchPicker color={ this.state.color } onChange={ this.handleChange } />
+          </div>
         </div> : null }
 
       </div>

--- a/package.json
+++ b/package.json
@@ -40,13 +40,9 @@
     "lodash.throttle": "^4.0.0",
     "material-colors": "^1.0.0",
     "merge": "^1.2.0",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
+    "react-addons-shallow-compare": "^0.14.0",
     "reactcss": "^0.4.3",
     "tinycolor2": "^1.1.2"
-  },
-  "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
@@ -66,8 +62,10 @@
     "jsx-loader": "^0.13.2",
     "mocha": "^2.4.5",
     "normalize.css": "^4.1.1",
-    "react-addons-test-utils": "^0.14.0 || ^15.0.0",
+    "react": "^0.14.7",
+    "react-addons-test-utils": "^0.14.0",
     "react-context": "0.0.3",
+    "react-dom": "^0.14.7",
     "react-hot-loader": "^1.2.8",
     "react-map-styles": "^0.3.0",
     "remarkable": "^1.6.0",


### PR DESCRIPTION
Added wrapper to doc examples to let users click within the color picker control to edit things like the hex values directly.

Updated package.json to get around unmet peer dependencies