### PR TITLE
Support for inside an iframe/webview

### DIFF
--- a/lib/components/common/Alpha.js
+++ b/lib/components/common/Alpha.js
@@ -49,7 +49,8 @@ var Alpha = exports.Alpha = function (_ReactCSS$Component) {
       var container = _this.refs.container;
       var containerWidth = container.clientWidth;
       var x = typeof e.pageX === 'number' ? e.pageX : e.touches[0].pageX;
-      var left = x - (container.getBoundingClientRect().left + window.pageXOffset);
+      var inIFrame = window.self !== window.top || window.document !== container.ownerDocument;
+      var left = x - (container.getBoundingClientRect().left + (inIFrame ? 0 : window.pageXOffset));
 
       var a;
       if (left < 0) {

--- a/lib/components/common/Hue.js
+++ b/lib/components/common/Hue.js
@@ -47,8 +47,9 @@ var Hue = exports.Hue = function (_ReactCSS$Component) {
       var containerHeight = container.clientHeight;
       var x = typeof e.pageX === 'number' ? e.pageX : e.touches[0].pageX;
       var y = typeof e.pageY === 'number' ? e.pageY : e.touches[0].pageY;
-      var left = x - (container.getBoundingClientRect().left + window.pageXOffset);
-      var top = y - (container.getBoundingClientRect().top + window.pageYOffset);
+      var inIFrame = window.self !== window.top || window.document !== container.ownerDocument;
+      var left = x - (container.getBoundingClientRect().left + (inIFrame ? 0 : window.pageXOffset));
+      var top = y - (container.getBoundingClientRect().top + (inIFrame ? 0 : window.pageYOffset));
 
       if (_this.props.direction === 'vertical') {
         var h;

--- a/lib/components/common/Saturation.js
+++ b/lib/components/common/Saturation.js
@@ -47,8 +47,9 @@ var Saturation = exports.Saturation = function (_ReactCSS$Component) {
       var containerHeight = container.clientHeight;
       var x = typeof e.pageX === 'number' ? e.pageX : e.touches[0].pageX;
       var y = typeof e.pageY === 'number' ? e.pageY : e.touches[0].pageY;
-      var left = x - (container.getBoundingClientRect().left + window.pageXOffset);
-      var top = y - (container.getBoundingClientRect().top + window.pageYOffset);
+      var inIFrame = window.self !== window.top || window.document !== container.ownerDocument;
+      var left = x - (container.getBoundingClientRect().left + (inIFrame ? 0 : window.pageXOffset));
+      var top = y - (container.getBoundingClientRect().top + (inIFrame ? 0 : window.pageYOffset));
 
       if (left < 0) {
         left = 0;

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -57,7 +57,8 @@ export class Alpha extends ReactCSS.Component {
     var container = this.refs.container
     var containerWidth = container.clientWidth
     var x = typeof e.pageX === 'number' ? e.pageX : e.touches[0].pageX
-    var left = x - (container.getBoundingClientRect().left + window.pageXOffset)
+    var inIFrame = window.self !== window.top || window.document !== container.ownerDocument
+    var left = x - (container.getBoundingClientRect().left + (inIFrame ? 0 : window.pageXOffset))
 
     var a
     if (left < 0) {

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -58,8 +58,9 @@ export class Hue extends ReactCSS.Component {
     var containerHeight = container.clientHeight
     var x = typeof e.pageX === 'number' ? e.pageX : e.touches[0].pageX
     var y = typeof e.pageY === 'number' ? e.pageY : e.touches[0].pageY
-    var left = x - (container.getBoundingClientRect().left + window.pageXOffset)
-    var top = y - (container.getBoundingClientRect().top + window.pageYOffset)
+    var inIFrame = window.self !== window.top || window.document !== container.ownerDocument
+    var left = x - (container.getBoundingClientRect().left + (inIFrame ? 0 : window.pageXOffset))
+    var top = y - (container.getBoundingClientRect().top + (inIFrame ? 0 : window.pageYOffset))
 
     if (this.props.direction === 'vertical') {
       var h

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -62,8 +62,9 @@ export class Saturation extends ReactCSS.Component {
     var containerHeight = container.clientHeight
     var x = typeof e.pageX === 'number' ? e.pageX : e.touches[0].pageX
     var y = typeof e.pageY === 'number' ? e.pageY : e.touches[0].pageY
-    var left = x - (container.getBoundingClientRect().left + window.pageXOffset)
-    var top = y - (container.getBoundingClientRect().top + window.pageYOffset)
+    var inIFrame = window.self !== window.top || window.document !== container.ownerDocument
+    var left = x - (container.getBoundingClientRect().left + (inIFrame ? 0 : window.pageXOffset))
+    var top = y - (container.getBoundingClientRect().top + (inIFrame ? 0 : window.pageYOffset))
 
     if (left < 0) {
       left = 0


### PR DESCRIPTION
I've implemented react-color inside an iframe inside an electron webview and this change allows clicks to work properly again (it was by default still getting the offset for the parent/topmost window, which would cause the click to happen outside of the react-color view).