### PR TITLE
Use modularized lodash

### DIFF
--- a/modules/react-material-design/src/components/Link.js
+++ b/modules/react-material-design/src/components/Link.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import React from 'react';
-import _ from 'lodash';
+import isString from 'lodash/isString';
 
 class Link extends React.Component {
 
@@ -19,7 +19,7 @@ class Link extends React.Component {
   render() {
 
     var a;
-    if (_.isString(this.props.onClick)) {
+    if (isString(this.props.onClick)) {
       a = <a style={{ textDecoration: 'none' }} href={ this.props.onClick } target={ this.props.newTab && '_blank' }>{ this.props.children }</a>;
     } else {
       a = <a style={{ textDecoration: 'none' }} onClick={ this.handleClick }>{ this.props.children }</a>;

--- a/modules/react-material-design/src/components/Tabs.js
+++ b/modules/react-material-design/src/components/Tabs.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import ReactCSS from 'reactcss';
-import _ from 'lodash';
+import isString from 'lodash/isString';
 
 import Tab from './Tab';
 import Link from './Link';
@@ -178,7 +178,7 @@ class Tabs extends ReactCSS.Component {
       var callback;
       var callbackValue;
       var newTab;
-      if (_.isString(tab)) {
+      if (isString(tab)) {
         label = tab;
         callback = null;
       } else {

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
   ],
   "dependencies": {
     "lodash": "^4.0.1",
-    "lodash.debounce": "^4.0.0",
-    "lodash.isplainobject": "^4.0.0",
-    "lodash.throttle": "^4.0.0",
     "material-colors": "^1.0.0",
     "merge": "^1.2.0",
     "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "normalize.css": "^4.1.1",
     "react-addons-test-utils": "^0.14.0 || ^15.0.0",
     "react-context": "0.0.3",
+    "react-dom": "^0.14.0 || ^15.0.0",
     "react-hot-loader": "^1.2.8",
     "react-map-styles": "^0.3.0",
     "remarkable": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "babel-cli": "^6.8.0",
     "babel-core": "^6.4.0",
     "babel-loader": "^6.2.1",
-    "babel-plugin-lodash": "^3.1.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",

--- a/src/components/common/ColorWrap.js
+++ b/src/components/common/ColorWrap.js
@@ -2,8 +2,8 @@
 
 import React from 'react'
 import merge from 'merge'
-import isPlainObject from 'lodash.isplainobject'
-import debounce from 'lodash.debounce'
+import isPlainObject from 'lodash/isPlainObject'
+import debounce from 'lodash/debounce'
 import color from '../../helpers/color'
 import shallowCompare from 'react-addons-shallow-compare'
 

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -2,7 +2,7 @@
 
 import React from 'react'
 import ReactCSS from 'reactcss'
-import throttle from 'lodash.throttle'
+import throttle from 'lodash/throttle'
 import shallowCompare from 'react-addons-shallow-compare'
 
 export class Saturation extends ReactCSS.Component {


### PR DESCRIPTION
react-color right now includes the full lodash 4, which overwrites `window._`. There are various issues about this in the lodash repo (lodash/lodash#2251 etc) closed as wontfix.

I believe this fixes #134, but I'm not sure if I've managed to build everything correctly. I didn't include any compiled files in the PR because of this. It would be nice if you could guide me through the process, or help me build everything and make sure it looks ok.

Together with a PR coming soon to reactcss updating to use the same approach to lodash, I think I managed to shave 335k off of the previous unminified build, although that's probably split around several dependencies being updated in the process.