### PR TITLE
Added an addClassName prop to PhotoshopPicker to add classnames

### DIFF
--- a/lib/components/photoshop/Photoshop.js
+++ b/lib/components/photoshop/Photoshop.js
@@ -34,7 +34,13 @@ var _PhotoshopPointer = require('./PhotoshopPointer');
 
 var _PhotoshopPointer2 = _interopRequireDefault(_PhotoshopPointer);
 
+var _classnames = require('classnames');
+
+var _classnames2 = _interopRequireDefault(_classnames);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
@@ -174,23 +180,26 @@ var Photoshop = exports.Photoshop = function (_ReactCSS$Component) {
   }, {
     key: 'render',
     value: function render() {
-      var header;
+      var _ClassNames3;
 
+      var header;
+      var mainClass = (0, _classnames2.default)(_defineProperty({}, '' + this.props.addClassName, Boolean(this.props.addClassName)));
+      var headerClass = (0, _classnames2.default)(_defineProperty({}, this.props.addClassName + '-header', Boolean(this.props.addClassName)));
+      var bodyClass = (0, _classnames2.default)((_ClassNames3 = {}, _defineProperty(_ClassNames3, this.props.addClassName + '-body', Boolean(this.props.addClassName)), _defineProperty(_ClassNames3, 'flexbox-fix', true), _ClassNames3));
       if (this.props.header) {
         header = _react2.default.createElement(
           'div',
-          { style: this.styles().head },
+          { className: headerClass, style: this.styles().head },
           this.props.header
         );
       }
-
       return _react2.default.createElement(
         'div',
-        { style: this.styles().picker },
+        { className: mainClass, style: this.styles().picker },
         header,
         _react2.default.createElement(
           'div',
-          { style: this.styles().body, className: 'flexbox-fix' },
+          { style: this.styles().body, className: bodyClass },
           _react2.default.createElement(
             'div',
             { style: this.styles().saturation },

--- a/src/components/photoshop/Photoshop.js
+++ b/src/components/photoshop/Photoshop.js
@@ -8,6 +8,7 @@ import { ColorWrap, Saturation, Hue } from '../common'
 import PhotoshopFields from './PhotoshopFields'
 import PhotoshopPointerCircle from './PhotoshopPointerCircle'
 import PhotoshopPointer from './PhotoshopPointer'
+import ClassNames from 'classnames'
 
 export class Photoshop extends ReactCSS.Component {
   shouldComponentUpdate = shallowCompare.bind(this, this, arguments[0], arguments[1]);
@@ -134,43 +135,47 @@ export class Photoshop extends ReactCSS.Component {
 
   render(): any {
     var header
-
+    let mainClass = ClassNames({ [`${this.props.addClassName}`]: Boolean(this.props.addClassName) });
+    let headerClass = ClassNames({ [`${this.props.addClassName}-header`]: Boolean(this.props.addClassName) });
+    let bodyClass = ClassNames({
+      [`${this.props.addClassName}-body`]: Boolean(this.props.addClassName),
+      'flexbox-fix': true
+    });
     if (this.props.header) {
-      header = <div is="head">
+      header = <div className={headerClass} is="head">
         { this.props.header }
       </div>
     }
-
     return (
-      <div is="picker">
-        { header }
-        <div is="body" className="flexbox-fix">
-          <div is="saturation">
-            <Saturation is="Saturation" {...this.props} pointer={ PhotoshopPointerCircle } onChange={ this.handleChange }/>
-          </div>
-          <div is="hue">
-            <Hue is="Hue" {...this.props} pointer={ PhotoshopPointer } onChange={ this.handleChange } />
-          </div>
-          <div is="controls">
-            <div is="top" className="flexbox-fix">
-              <div is="previews">
-                <div is="label">new</div>
-                <div is="swatches">
-                  <div is="new" />
-                  <div is="current" />
+        <div className={mainClass} is="picker">
+          { header }
+          <div is="body" className={bodyClass}>
+            <div is="saturation">
+              <Saturation is="Saturation" {...this.props} pointer={ PhotoshopPointerCircle } onChange={ this.handleChange }/>
+            </div>
+            <div is="hue">
+              <Hue is="Hue" {...this.props} pointer={ PhotoshopPointer } onChange={ this.handleChange } />
+            </div>
+            <div is="controls">
+              <div is="top" className="flexbox-fix">
+                <div is="previews">
+                  <div is="label">new</div>
+                  <div is="swatches">
+                    <div is="new" />
+                    <div is="current" />
+                  </div>
+                  <div is="label">current</div>
                 </div>
-                <div is="label">current</div>
-              </div>
-              <div is="actions">
-                <div is="acceptButton" ref="accept" onClick={ this.handleAccept }>OK</div>
-                <div is="button" ref="cancel" onClick={ this.handleCancel }>Cancel</div>
+                <div is="actions">
+                  <div is="acceptButton" ref="accept" onClick={ this.handleAccept }>OK</div>
+                  <div is="button" ref="cancel" onClick={ this.handleCancel }>Cancel</div>
 
-                <PhotoshopFields {...this.props} />
+                  <PhotoshopFields {...this.props} />
+                </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
     )
   }
 }


### PR DESCRIPTION
Added an addClassName prop to PhotoshopPicker to add classnames optionally. This is needed for some parent components to be able to ignore events coming from classes with certain names.