### PR TITLE
Fix issue with missing stacking context on EditableInput

### DIFF
--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -106,7 +106,9 @@ export class EditableInput extends React.Component {
   render(): any {
     const styles = reactCSS({
       'user-override': {
-        wrap: this.props.style && this.props.style.wrap ? this.props.style.wrap : {},
+        wrap: this.props.style && this.props.style.wrap
+          ? this.props.style.wrap
+          : { position: 'relative' },
         input: this.props.style && this.props.style.input ? this.props.style.input : {},
         label: this.props.style && this.props.style.label ? this.props.style.label : {},
       },


### PR DESCRIPTION
This would fix #179

Unfortunately I am not able to run tests / build anything locally due to the fact that CONTRIBUTING.md is still talking about an inexsistent gulp-workflow and the npm scripts specified in package.json will complain about  a missing `react-addons-shallow-compare`.