### PR TITLE
added unique key prop to <Swatch /> components

### DIFF
--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -99,9 +99,9 @@ export class Twitter extends React.Component {
 
         <div style={ styles.body }>
 
-          { map(this.props.colors, (c, idx) => {
+          { map(this.props.colors, (c, i) => {
             return (
-              <Swatch key={idx} color={ c } hex={ c } style={ styles.swatch } onClick={ this.handleChange } />
+              <Swatch key={ i } color={ c } hex={ c } style={ styles.swatch } onClick={ this.handleChange } />
             )
           }) }
           <div style={ styles.hash }>#</div>

--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -99,9 +99,9 @@ export class Twitter extends React.Component {
 
         <div style={ styles.body }>
 
-          { map(this.props.colors, (c) => {
+          { map(this.props.colors, (c, idx) => {
             return (
-              <Swatch color={ c } hex={ c } style={ styles.swatch } onClick={ this.handleChange } />
+              <Swatch key={idx} color={ c } hex={ c } style={ styles.swatch } onClick={ this.handleChange } />
             )
           }) }
           <div style={ styles.hash }>#</div>


### PR DESCRIPTION
Child components should all have unique keys per the React documentation. React will actually log an error to the console if no key is provided. This is a tiny change that adds a key to the Swatch components in the TwitterPicker only, using their index as the unique key. This will improve React's performance as well as stop the unnecessary errors.