### PR TITLE
Handle Saturation pointer position in component state

### DIFF
--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -9,6 +9,11 @@ export class Saturation extends React.Component {
   constructor(props: any) {
     super(props)
 
+    this.state = {
+      saturation: this.props.hsv.s * 100,
+      bright: this.props.hsv.v * 100,
+    }
+
     this.throttle = throttle((fn: any, data: any) => {
       fn(data)
     }, 50)
@@ -44,6 +49,7 @@ export class Saturation extends React.Component {
     const saturation = left * 100 / containerWidth
     const bright = -(top * 100 / containerHeight) + 100
 
+    this.setState({ saturation, bright })
     this.throttle(this.props.onChange, {
       h: this.props.hsl.h,
       s: saturation,
@@ -87,8 +93,8 @@ export class Saturation extends React.Component {
         },
         pointer: {
           position: 'absolute',
-          top: `${ -(this.props.hsv.v * 100) + 100 }%`,
-          left: `${ this.props.hsv.s * 100 }%`,
+          top: `${ Math.max(0, Math.min(100, 100 - this.state.bright)) }%`,
+          left: `${ Math.max(0, Math.min(100, this.state.saturation)) }%`,
           cursor: 'default',
         },
         circle: {


### PR DESCRIPTION
Following up from #216, here's a PR showing how I'm using the Saturation component's internal state for the pointer position, in order to avoid the jumpiness at the low-brightness threshold coming from the round-trip conversion to a color value and back.

The problem is that it only uses `props.hsv` when the component is constructed and then stops looking at it. This means that on the docs page, when there's a handful of pickers open all at once, updating props no longer syncs all the pickers anymore. This wasn't a problem for my own app, where I only have one picker open at a time, and it's never a persistent picker so it only needs the initial prop once.

Not sure what the best way forward is, but I thought I'd open this up for discussion and your thoughts.
