### PR TITLE
Add Alpha Styles Overwrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
-    "babel-core": "^6.4.0",
+    "babel-core": "^6.10.4",
     "babel-eslint": "^6.1.2",
     "babel-loader": "^6.2.1",
     "babel-preset-es2015": "^6.3.13",

--- a/src/components/alpha/Alpha.js
+++ b/src/components/alpha/Alpha.js
@@ -25,6 +25,7 @@ export const AlphaPicker = (props) => {
   return (
     <div style={ styles.alpha } className="alpha-picker">
       <Alpha
+        style={ props.style }
         { ...styles.Alpha }
         { ...props }
         pointer={ AlphaPointer }

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -94,7 +94,10 @@ export class Alpha extends React.Component {
           transform: 'translateX(-2px)',
         },
       },
-    })
+      'overwrite': {
+        ...this.props.style,
+      },
+    }, 'overwrite')
 
     let pointer = this.props.pointer ? (
       <this.props.pointer { ...this.props } />


### PR DESCRIPTION
Fixes https://github.com/casesandberg/react-color/issues/259

Color can be overridden like this: `style={{ gradient: { background: '#fff' } }}`