### PR TITLE
Add css cursor to PhotoshopButton

### DIFF
--- a/src/components/photoshop/PhotoshopButton.js
+++ b/src/components/photoshop/PhotoshopButton.js
@@ -15,6 +15,7 @@ export const PhotoshopBotton = (props) => {
         lineHeight: '20px',
         textAlign: 'center',
         marginBottom: '10px',
+        cursor: 'pointer',
       },
     },
     'active': {


### PR DESCRIPTION
Hover above the button text (OK, Cancel) shows a caret cursor without this fix.