### PR TITLE
BUG: Remove correct event listener in `EditableInput`

### DIFF
--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -99,7 +99,7 @@ export class EditableInput extends React.Component {
   }
 
   unbindEventListeners = () => {
-    window.removeEventListener('mousemove', this.handleChange)
+    window.removeEventListener('mousemove', this.handleDrag)
     window.removeEventListener('mouseup', this.handleMouseUp)
   }
 


### PR DESCRIPTION
Fixes: https://github.com/casesandberg/react-color/issues/260