### PR TITLE
Add react-addons-shallow-compare back to dependencies (#281)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "lodash": "^4.0.1",
     "material-colors": "^1.0.0",
+    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "reactcss": "^1.0.6",
     "tinycolor2": "^1.1.2"
   },
@@ -73,7 +74,6 @@
     "mocha": "^2.4.5",
     "normalize.css": "^4.1.1",
     "react": "^15.3.2",
-    "react-addons-shallow-compare": "^0.14.0 || ^15.0.0",
     "react-addons-test-utils": "^0.14.0 || ^15.0.0",
     "react-context": "0.0.3",
     "react-dom": "^0.14.0 || ^15.0.0",


### PR DESCRIPTION
Moves react-addons-shallow-compare back to dependencies to resolve https://github.com/casesandberg/react-color/issues/281