### PR TITLE
Allow optional label on block swatches

### DIFF
--- a/src/components/block/BlockSwatches.js
+++ b/src/components/block/BlockSwatches.js
@@ -27,12 +27,14 @@ export const BlockSwatches = ({ colors, onClick }) => {
   return (
     <div style={ styles.swatches }>
       { map(colors, (c) => (
-        <Swatch
-          key={ c }
-          color={ c }
-          style={ styles.swatch }
-          onClick={ onClick }
-        />
+        <div key={ c.hex || c }>
+          <Swatch
+            color={ c.hex || c }
+            style={ styles.swatch }
+            onClick={ onClick }
+          />
+          {c.label && <p>{c.label}</p>}
+        </div>
       )) }
       <div style={ styles.clear } />
     </div>


### PR DESCRIPTION
I wanted to add labels to the colors in the BlockPicker (semantic labels for my specific use case).  I was first experimenting with how I would accomplish this by making the changes directly to the BlockPicker.  I wanted to find out if there was any interest by the project before I go on and make a custom component for it.