### PR TITLE
Use html title attribute on Swatch

### DIFF
--- a/src/components/block/__snapshots__/spec.js.snap
+++ b/src/components/block/__snapshots__/spec.js.snap
@@ -87,7 +87,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#D9E3F0" />
       <div
         onClick={[Function]}
         style={
@@ -105,7 +106,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#F47373" />
       <div
         onClick={[Function]}
         style={
@@ -123,7 +125,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#697689" />
       <div
         onClick={[Function]}
         style={
@@ -141,7 +144,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#37D67A" />
       <div
         onClick={[Function]}
         style={
@@ -159,7 +163,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#2CCCE4" />
       <div
         onClick={[Function]}
         style={
@@ -177,7 +182,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#555555" />
       <div
         onClick={[Function]}
         style={
@@ -195,7 +201,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#dce775" />
       <div
         onClick={[Function]}
         style={
@@ -213,7 +220,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#ff8a65" />
       <div
         onClick={[Function]}
         style={
@@ -231,7 +239,8 @@ exports[`test Block \`triangle="none"\` 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#ba68c8" />
       <div
         style={
           Object {
@@ -367,7 +376,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#D9E3F0" />
       <div
         onClick={[Function]}
         style={
@@ -385,7 +395,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#F47373" />
       <div
         onClick={[Function]}
         style={
@@ -403,7 +414,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#697689" />
       <div
         onClick={[Function]}
         style={
@@ -421,7 +433,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#37D67A" />
       <div
         onClick={[Function]}
         style={
@@ -439,7 +452,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#2CCCE4" />
       <div
         onClick={[Function]}
         style={
@@ -457,7 +471,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#555555" />
       <div
         onClick={[Function]}
         style={
@@ -475,7 +490,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#dce775" />
       <div
         onClick={[Function]}
         style={
@@ -493,7 +509,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#ff8a65" />
       <div
         onClick={[Function]}
         style={
@@ -511,7 +528,8 @@ exports[`test Block renders correctly 1`] = `
             "msBorderRadius": "4px",
             "width": "22px",
           }
-        } />
+        }
+        title="#ba68c8" />
       <div
         style={
           Object {
@@ -582,7 +600,8 @@ exports[`test BlockSwatches renders correctly 1`] = `
         "msBorderRadius": "4px",
         "width": "22px",
       }
-    } />
+    }
+    title="#fff" />
   <div
     onClick={[Function]}
     style={
@@ -600,7 +619,8 @@ exports[`test BlockSwatches renders correctly 1`] = `
         "msBorderRadius": "4px",
         "width": "22px",
       }
-    } />
+    }
+    title="#999" />
   <div
     onClick={[Function]}
     style={
@@ -618,7 +638,8 @@ exports[`test BlockSwatches renders correctly 1`] = `
         "msBorderRadius": "4px",
         "width": "22px",
       }
-    } />
+    }
+    title="#000" />
   <div
     style={
       Object {

--- a/src/components/circle/__snapshots__/spec.js.snap
+++ b/src/components/circle/__snapshots__/spec.js.snap
@@ -56,7 +56,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#f44336" />
     </div>
   </span>
   <span
@@ -105,7 +106,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#e91e63" />
     </div>
   </span>
   <span
@@ -154,7 +156,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#9c27b0" />
     </div>
   </span>
   <span
@@ -203,7 +206,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#673ab7" />
     </div>
   </span>
   <span
@@ -252,7 +256,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#3f51b5" />
     </div>
   </span>
   <span
@@ -301,7 +306,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#2196f3" />
     </div>
   </span>
   <span
@@ -350,7 +356,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#03a9f4" />
     </div>
   </span>
   <span
@@ -399,7 +406,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#00bcd4" />
     </div>
   </span>
   <span
@@ -448,7 +456,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#009688" />
     </div>
   </span>
   <span
@@ -497,7 +506,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#4caf50" />
     </div>
   </span>
   <span
@@ -546,7 +556,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#8bc34a" />
     </div>
   </span>
   <span
@@ -595,7 +606,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#cddc39" />
     </div>
   </span>
   <span
@@ -644,7 +656,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#ffeb3b" />
     </div>
   </span>
   <span
@@ -693,7 +706,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#ffc107" />
     </div>
   </span>
   <span
@@ -742,7 +756,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#ff9800" />
     </div>
   </span>
   <span
@@ -791,7 +806,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#ff5722" />
     </div>
   </span>
   <span
@@ -840,7 +856,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#795548" />
     </div>
   </span>
   <span
@@ -889,7 +906,8 @@ exports[`test Circle renders correctly 1`] = `
             "transition": "100ms box-shadow ease",
             "width": "100%",
           }
-        } />
+        }
+        title="#607d8b" />
     </div>
   </span>
 </div>
@@ -942,7 +960,8 @@ exports[`test CircleSwatch renders correctly 1`] = `
           "transition": "100ms box-shadow ease",
           "width": "100%",
         }
-      } />
+      }
+      title={undefined} />
   </div>
 </span>
 `;
@@ -994,7 +1013,8 @@ exports[`test CircleSwatch renders with sizing and spacing 1`] = `
           "transition": "100ms box-shadow ease",
           "width": "100%",
         }
-      } />
+      }
+      title={undefined} />
   </div>
 </span>
 `;

--- a/src/components/common/Swatch.js
+++ b/src/components/common/Swatch.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import reactCSS from 'reactcss'
 
-export const Swatch = ({ color, style, onClick }) => {
+export const Swatch = ({ color, style, onClick, title = color }) => {
   const styles = reactCSS({
     'default': {
       swatch: {
@@ -19,7 +19,7 @@ export const Swatch = ({ color, style, onClick }) => {
   const handleClick = (e) => onClick(color, e)
 
   return (
-    <div style={ styles.swatch } onClick={ handleClick } />
+    <div style={ styles.swatch } onClick={ handleClick } title={ title } />
   )
 }
 

--- a/src/components/common/__snapshots__/spec.js.snap
+++ b/src/components/common/__snapshots__/spec.js.snap
@@ -312,5 +312,20 @@ exports[`test Swatch renders correctly 1`] = `
       "opacity": "0.4",
       "width": "100%",
     }
-  } />
+  }
+  title="#333" />
+`;
+
+exports[`test Swatch renders custom title correctly 1`] = `
+<div
+  onClick={[Function]}
+  style={
+    Object {
+      "background": "#fff",
+      "cursor": "pointer",
+      "height": "100%",
+      "width": "100%",
+    }
+  }
+  title="white" />
 `;

--- a/src/components/common/spec.js
+++ b/src/components/common/spec.js
@@ -67,3 +67,10 @@ test('Swatch renders correctly', () => {
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+test('Swatch renders custom title correctly', () => {
+  const tree = renderer.create(
+    <Swatch color="#fff" title="white" />
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})

--- a/src/components/github/__snapshots__/spec.js.snap
+++ b/src/components/github/__snapshots__/spec.js.snap
@@ -57,7 +57,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#B80000" />
     </div>
   </span>
   <span
@@ -79,7 +80,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#DB3E00" />
     </div>
   </span>
   <span
@@ -101,7 +103,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FCCB00" />
     </div>
   </span>
   <span
@@ -123,7 +126,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#008B02" />
     </div>
   </span>
   <span
@@ -145,7 +149,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#006B76" />
     </div>
   </span>
   <span
@@ -167,7 +172,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#1273DE" />
     </div>
   </span>
   <span
@@ -189,7 +195,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#004DCF" />
     </div>
   </span>
   <span
@@ -211,7 +218,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#5300EB" />
     </div>
   </span>
   <span
@@ -233,7 +241,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#EB9694" />
     </div>
   </span>
   <span
@@ -255,7 +264,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FAD0C3" />
     </div>
   </span>
   <span
@@ -277,7 +287,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FEF3BD" />
     </div>
   </span>
   <span
@@ -299,7 +310,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#C1E1C5" />
     </div>
   </span>
   <span
@@ -321,7 +333,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#BEDADC" />
     </div>
   </span>
   <span
@@ -343,7 +356,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#C4DEF6" />
     </div>
   </span>
   <span
@@ -365,7 +379,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#BED3F3" />
     </div>
   </span>
   <span
@@ -387,7 +402,8 @@ exports[`test Github \`triangle="none"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#D4C4FB" />
     </div>
   </span>
 </div>
@@ -456,7 +472,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#B80000" />
     </div>
   </span>
   <span
@@ -478,7 +495,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#DB3E00" />
     </div>
   </span>
   <span
@@ -500,7 +518,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FCCB00" />
     </div>
   </span>
   <span
@@ -522,7 +541,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#008B02" />
     </div>
   </span>
   <span
@@ -544,7 +564,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#006B76" />
     </div>
   </span>
   <span
@@ -566,7 +587,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#1273DE" />
     </div>
   </span>
   <span
@@ -588,7 +610,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#004DCF" />
     </div>
   </span>
   <span
@@ -610,7 +633,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#5300EB" />
     </div>
   </span>
   <span
@@ -632,7 +656,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#EB9694" />
     </div>
   </span>
   <span
@@ -654,7 +679,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FAD0C3" />
     </div>
   </span>
   <span
@@ -676,7 +702,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FEF3BD" />
     </div>
   </span>
   <span
@@ -698,7 +725,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#C1E1C5" />
     </div>
   </span>
   <span
@@ -720,7 +748,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#BEDADC" />
     </div>
   </span>
   <span
@@ -742,7 +771,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#C4DEF6" />
     </div>
   </span>
   <span
@@ -764,7 +794,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#BED3F3" />
     </div>
   </span>
   <span
@@ -786,7 +817,8 @@ exports[`test Github \`triangle="top-right"\` 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#D4C4FB" />
     </div>
   </span>
 </div>
@@ -855,7 +887,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#B80000" />
     </div>
   </span>
   <span
@@ -877,7 +910,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#DB3E00" />
     </div>
   </span>
   <span
@@ -899,7 +933,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FCCB00" />
     </div>
   </span>
   <span
@@ -921,7 +956,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#008B02" />
     </div>
   </span>
   <span
@@ -943,7 +979,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#006B76" />
     </div>
   </span>
   <span
@@ -965,7 +1002,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#1273DE" />
     </div>
   </span>
   <span
@@ -987,7 +1025,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#004DCF" />
     </div>
   </span>
   <span
@@ -1009,7 +1048,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#5300EB" />
     </div>
   </span>
   <span
@@ -1031,7 +1071,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#EB9694" />
     </div>
   </span>
   <span
@@ -1053,7 +1094,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FAD0C3" />
     </div>
   </span>
   <span
@@ -1075,7 +1117,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#FEF3BD" />
     </div>
   </span>
   <span
@@ -1097,7 +1140,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#C1E1C5" />
     </div>
   </span>
   <span
@@ -1119,7 +1163,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#BEDADC" />
     </div>
   </span>
   <span
@@ -1141,7 +1186,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#C4DEF6" />
     </div>
   </span>
   <span
@@ -1163,7 +1209,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#BED3F3" />
     </div>
   </span>
   <span
@@ -1185,7 +1232,8 @@ exports[`test Github renders correctly 1`] = `
             "height": "100%",
             "width": "100%",
           }
-        } />
+        }
+        title="#D4C4FB" />
     </div>
   </span>
 </div>
@@ -1211,7 +1259,8 @@ exports[`test GithubSwatch renders correctly 1`] = `
           "height": "100%",
           "width": "100%",
         }
-      } />
+      }
+      title="#333" />
   </div>
 </span>
 `;

--- a/src/components/sketch/__snapshots__/spec.js.snap
+++ b/src/components/sketch/__snapshots__/spec.js.snap
@@ -689,7 +689,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#D0021B" />
     </div>
     <div
       style={
@@ -718,7 +719,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#F5A623" />
     </div>
     <div
       style={
@@ -747,7 +749,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#F8E71C" />
     </div>
     <div
       style={
@@ -776,7 +779,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#8B572A" />
     </div>
     <div
       style={
@@ -805,7 +809,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#7ED321" />
     </div>
     <div
       style={
@@ -834,7 +839,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#417505" />
     </div>
     <div
       style={
@@ -863,7 +869,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#BD10E0" />
     </div>
     <div
       style={
@@ -892,7 +899,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#9013FE" />
     </div>
     <div
       style={
@@ -921,7 +929,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#4A90E2" />
     </div>
     <div
       style={
@@ -950,7 +959,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#50E3C2" />
     </div>
     <div
       style={
@@ -979,7 +989,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#B8E986" />
     </div>
     <div
       style={
@@ -1008,7 +1019,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#000000" />
     </div>
     <div
       style={
@@ -1037,7 +1049,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#4A4A4A" />
     </div>
     <div
       style={
@@ -1066,7 +1079,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#9B9B9B" />
     </div>
     <div
       style={
@@ -1095,7 +1109,8 @@ exports[`test Sketch renders correctly 1`] = `
             "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
             "width": "100%",
           }
-        } />
+        }
+        title="#FFFFFF" />
     </div>
   </div>
 </div>
@@ -1420,7 +1435,8 @@ exports[`test SketchPresetColors renders correctly 1`] = `
           "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
           "width": "100%",
         }
-      } />
+      }
+      title="#fff" />
   </div>
   <div
     style={
@@ -1449,7 +1465,8 @@ exports[`test SketchPresetColors renders correctly 1`] = `
           "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
           "width": "100%",
         }
-      } />
+      }
+      title="#999" />
   </div>
   <div
     style={
@@ -1478,7 +1495,8 @@ exports[`test SketchPresetColors renders correctly 1`] = `
           "msBoxShadow": "inset 0 0 0 1px rgba(0,0,0,.15)",
           "width": "100%",
         }
-      } />
+      }
+      title="#000" />
   </div>
 </div>
 `;

--- a/src/components/twitter/__snapshots__/spec.js.snap
+++ b/src/components/twitter/__snapshots__/spec.js.snap
@@ -63,7 +63,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#FF6900" />
     <div
       onClick={[Function]}
       style={
@@ -80,7 +81,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#FCB900" />
     <div
       onClick={[Function]}
       style={
@@ -97,7 +99,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#7BDCB5" />
     <div
       onClick={[Function]}
       style={
@@ -114,7 +117,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#00D084" />
     <div
       onClick={[Function]}
       style={
@@ -131,7 +135,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#8ED1FC" />
     <div
       onClick={[Function]}
       style={
@@ -148,7 +153,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#0693E3" />
     <div
       onClick={[Function]}
       style={
@@ -165,7 +171,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#ABB8C3" />
     <div
       onClick={[Function]}
       style={
@@ -182,7 +189,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#EB144C" />
     <div
       onClick={[Function]}
       style={
@@ -199,7 +207,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#F78DA7" />
     <div
       onClick={[Function]}
       style={
@@ -216,7 +225,8 @@ exports[`test Twitter \`triangle="none"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#9900EF" />
     <div
       style={
         Object {
@@ -352,7 +362,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#FF6900" />
     <div
       onClick={[Function]}
       style={
@@ -369,7 +380,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#FCB900" />
     <div
       onClick={[Function]}
       style={
@@ -386,7 +398,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#7BDCB5" />
     <div
       onClick={[Function]}
       style={
@@ -403,7 +416,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#00D084" />
     <div
       onClick={[Function]}
       style={
@@ -420,7 +434,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#8ED1FC" />
     <div
       onClick={[Function]}
       style={
@@ -437,7 +452,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#0693E3" />
     <div
       onClick={[Function]}
       style={
@@ -454,7 +470,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#ABB8C3" />
     <div
       onClick={[Function]}
       style={
@@ -471,7 +488,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#EB144C" />
     <div
       onClick={[Function]}
       style={
@@ -488,7 +506,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#F78DA7" />
     <div
       onClick={[Function]}
       style={
@@ -505,7 +524,8 @@ exports[`test Twitter \`triangle="top-right"\` 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#9900EF" />
     <div
       style={
         Object {
@@ -641,7 +661,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#FF6900" />
     <div
       onClick={[Function]}
       style={
@@ -658,7 +679,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#FCB900" />
     <div
       onClick={[Function]}
       style={
@@ -675,7 +697,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#7BDCB5" />
     <div
       onClick={[Function]}
       style={
@@ -692,7 +715,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#00D084" />
     <div
       onClick={[Function]}
       style={
@@ -709,7 +733,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#8ED1FC" />
     <div
       onClick={[Function]}
       style={
@@ -726,7 +751,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#0693E3" />
     <div
       onClick={[Function]}
       style={
@@ -743,7 +769,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#ABB8C3" />
     <div
       onClick={[Function]}
       style={
@@ -760,7 +787,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#EB144C" />
     <div
       onClick={[Function]}
       style={
@@ -777,7 +805,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#F78DA7" />
     <div
       onClick={[Function]}
       style={
@@ -794,7 +823,8 @@ exports[`test Twitter renders correctly 1`] = `
           "msBorderRadius": "4px",
           "width": "30px",
         }
-      } />
+      }
+      title="#9900EF" />
     <div
       style={
         Object {


### PR DESCRIPTION
Add title prop to Swatch (defaults to color prop value). This provides both a built-in tooltip-like display as well as some semantic accessibility improvements.

Partial solution for #307