### PR TITLE
Allow inputs with values of 0 to fire key-down events

### DIFF
--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -44,7 +44,7 @@ export class EditableInput extends (PureComponent || Component) {
 
   handleKeyDown = (e) => {
     const number = Number(e.target.value)
-    if (number) {
+    if (!isNaN(number)) {
       const amount = this.props.arrowOffset || 1
 
       // Up


### PR DESCRIPTION
Inputs with a value of `0` would ignore the `handleKeyDown` event because of the weak check.