### PR TITLE
Optimize bundle size

### DIFF
--- a/docs/documentation/02.02-include.md
+++ b/docs/documentation/02.02-include.md
@@ -15,3 +15,9 @@ class Component extends React.Component {
 }
 ```
 You can import `AlphaPicker` `BlockPicker` `ChromePicker` `CirclePicker` `CompactPicker` `GithubPicker` `HuePicker` `MaterialPicker` `PhotoshopPicker` `SketchPicker` `SliderPicker` `SwatchesPicker` `TwitterPicker` respectively.
+
+You can also import a picker individually to optimize your bundle size.
+```
+import SketchPicker from 'react-color/lib/Sketch';
+import ChromePicker from 'react-color/lib/Chrome';
+```

--- a/src/Alpha.js
+++ b/src/Alpha.js
@@ -1,0 +1,1 @@
+export default from './components/alpha/Alpha'

--- a/src/Block.js
+++ b/src/Block.js
@@ -1,0 +1,1 @@
+export default from './components/block/Block'

--- a/src/Chrome.js
+++ b/src/Chrome.js
@@ -1,0 +1,1 @@
+export default from './components/chrome/Chrome'

--- a/src/Circle.js
+++ b/src/Circle.js
@@ -1,0 +1,1 @@
+export default from './components/circle/Circle'

--- a/src/Compact.js
+++ b/src/Compact.js
@@ -1,0 +1,1 @@
+export default from './components/compact/Compact'

--- a/src/Custom.js
+++ b/src/Custom.js
@@ -1,0 +1,1 @@
+export default from './components/common/ColorWrap'

--- a/src/Github.js
+++ b/src/Github.js
@@ -1,0 +1,1 @@
+export default from './components/github/Github'

--- a/src/Hue.js
+++ b/src/Hue.js
@@ -1,0 +1,1 @@
+export default from './components/hue/Hue'

--- a/src/Material.js
+++ b/src/Material.js
@@ -1,0 +1,1 @@
+export default from './components/material/Material'

--- a/src/Photoshop.js
+++ b/src/Photoshop.js
@@ -1,0 +1,1 @@
+export default from './components/photoshop/Photoshop'

--- a/src/Sketch.js
+++ b/src/Sketch.js
@@ -1,0 +1,1 @@
+export default from './components/sketch/Sketch'

--- a/src/Slider.js
+++ b/src/Slider.js
@@ -1,0 +1,1 @@
+export default from './components/slider/Slider'

--- a/src/Swatches.js
+++ b/src/Swatches.js
@@ -1,0 +1,1 @@
+export default from './components/swatches/Swatches'

--- a/src/Twitter.js
+++ b/src/Twitter.js
@@ -1,0 +1,1 @@
+export default from './components/twitter/Twitter'


### PR DESCRIPTION
I am using create-react-app and after I analyzed my js bundle I saw react-color was taking 100kb and all pickers were imported.

![capture d ecran 2017-06-02 a 12 26 14](https://cloud.githubusercontent.com/assets/5749437/26722987/a48f65b2-4792-11e7-9950-4a93b643adca.png)

So I tried to import the picker individually. After that react-color was taking 44.8kb.
```javascript
import ChromePicker from 'react-color/lib/components/chrome/Chrome';
```
![capture d ecran 2017-06-02 a 12 26 36](https://cloud.githubusercontent.com/assets/5749437/26722989/a4aacbea-4792-11e7-8fb9-f207adc6316e.png)

With this changes we will be able to easily import each picker individually, ex:
```javascript
import SketchPicker from 'react-color/lib/Sketch';
import ChromePicker from 'react-color/lib/Chrome';
```