### PR TITLE
Fix the color object being handed to onSwatchHover

### DIFF
--- a/src/components/alpha/spec.js
+++ b/src/components/alpha/spec.js
@@ -2,10 +2,12 @@
 
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { red } from '../../helpers/color'
+import { mount } from 'enzyme';
+import color, { red } from '../../helpers/color'
 // import canvas from 'canvas'
 
 import Alpha from './Alpha'
+import { ColorWrap, Alpha as CommonAlpha } from '../common'
 import AlphaPointer from './AlphaPointer'
 
 test('Alpha renders correctly', () => {
@@ -21,6 +23,22 @@ test('Alpha renders correctly', () => {
 //   ).toJSON()
 //   expect(tree).toMatchSnapshot()
 // })
+
+test('Alpha onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Alpha { ...red } width={ 20 } height={ 200 } onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const alphaCommon = tree.find(CommonAlpha);
+  alphaCommon.at(0).childAt(2).simulate('mouseDown', {
+    pageX: 100,
+    pageY: 10,
+  })
+  expect(changeSpy).toHaveBeenCalled()
+})
 
 test('Alpha renders vertically', () => {
   const tree = renderer.create(

--- a/src/components/block/spec.js
+++ b/src/components/block/spec.js
@@ -7,6 +7,7 @@ import { mount } from 'enzyme';
 import Block from './Block'
 import BlockSwatches from './BlockSwatches'
 import { Swatch } from '../common'
+import color from '../../helpers/color'
 
 test('Block renders correctly', () => {
   const tree = renderer.create(
@@ -15,8 +16,24 @@ test('Block renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Block onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Block onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const swatches = tree.find(Swatch);
+  swatches.at(0).childAt(0).simulate('click')
+
+  expect(changeSpy).toHaveBeenCalled()
+})
+
 test('Block with onSwatchHover events correctly', () => {
-  const hoverSpy = jest.fn()
+  const hoverSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
   const tree = mount(
     <Block onSwatchHover={hoverSpy} />
   )

--- a/src/components/chrome/spec.js
+++ b/src/components/chrome/spec.js
@@ -2,19 +2,43 @@
 
 import React from 'react'
 import renderer from 'react-test-renderer'
-import { red } from '../../helpers/color'
-// import canvas from 'canvas'
+import color, { red } from '../../helpers/color'
+import { mount } from 'enzyme';
 
 import Chrome from './Chrome'
 import ChromeFields from './ChromeFields'
 import ChromePointer from './ChromePointer'
 import ChromePointerCircle from './ChromePointerCircle'
+import { ColorWrap, Saturation, Hue, Alpha as CommonAlpha } from '../common'
+
 
 test('Chrome renders correctly', () => {
   const tree = renderer.create(
     <Chrome { ...red } />
   ).toJSON()
   expect(tree).toMatchSnapshot()
+})
+
+test('Chrome onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Chrome { ...red } onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+
+  // check the Alpha component
+  const alphaCommon = tree.find(CommonAlpha);
+  alphaCommon.at(0).childAt(2).simulate('mouseDown', {
+    pageX: 100,
+    pageY: 10,
+  })
+  expect(changeSpy).toHaveBeenCalledTimes(1)
+
+  // TODO: check the Hue component
+  // TODO: check the ChromeFields
+  // TODO: check Saturation
 })
 
 // test('Chrome renders on server correctly', () => {

--- a/src/components/circle/spec.js
+++ b/src/components/circle/spec.js
@@ -7,6 +7,7 @@ import { mount } from 'enzyme';
 import Circle from './Circle'
 import CircleSwatch from './CircleSwatch'
 import { Swatch } from '../common'
+import color from '../../helpers/color'
 
 test('Circle renders correctly', () => {
   const tree = renderer.create(
@@ -15,8 +16,25 @@ test('Circle renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Circle onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Circle onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const swatches = tree.find(Swatch);
+  swatches.at(0).childAt(0).simulate('click')
+
+  expect(changeSpy).toHaveBeenCalled()
+})
+
+
 test('Circle with onSwatchHover events correctly', () => {
-  const hoverSpy = jest.fn()
+  const hoverSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
   const tree = mount(
     <Circle onSwatchHover={hoverSpy} />
   )

--- a/src/components/common/ColorWrap.js
+++ b/src/components/common/ColorWrap.js
@@ -22,7 +22,6 @@ export const ColorWrap = (Picker) => {
       })
     }
 
-
     handleChange = (data, event) => {
       const isValidColor = color.simpleCheckForValidColor(data)
       if (isValidColor) {
@@ -33,8 +32,22 @@ export const ColorWrap = (Picker) => {
       }
     }
 
+    handleSwatchHover = (data, event) => {
+      const isValidColor = color.simpleCheckForValidColor(data)
+      if (isValidColor) {
+        const colors = color.toState(data, data.h || this.state.oldHue)
+        this.setState(colors)
+        this.props.onSwatchHover && this.props.onSwatchHover(colors, event)
+      }
+    }
+
     render() {
-      return <Picker { ...this.props } { ...this.state } onChange={ this.handleChange } />
+      let optionalEvents = {}
+      if (this.props.onSwatchHover) {
+        optionalEvents.onSwatchHover = this.handleSwatchHover
+      }
+
+      return <Picker { ...this.props } { ...this.state } onChange={ this.handleChange } { ...optionalEvents } />
     }
   }
 

--- a/src/components/compact/spec.js
+++ b/src/components/compact/spec.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme';
-import { red } from '../../helpers/color'
+import color, { red } from '../../helpers/color'
 
 import Compact from './Compact'
 import CompactColor from './CompactColor'
@@ -24,8 +24,24 @@ test('Compact with onSwatchHover renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Compact onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Compact { ...red } onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const swatches = tree.find(Swatch);
+  swatches.at(0).childAt(0).simulate('click')
+
+  expect(changeSpy).toHaveBeenCalled()
+})
+
 test('Compact with onSwatchHover events correctly', () => {
-  const hoverSpy = jest.fn()
+  const hoverSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
   const tree = mount(
     <Compact { ...red } onSwatchHover={hoverSpy} />
   )

--- a/src/components/github/spec.js
+++ b/src/components/github/spec.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme';
-import { red } from '../../helpers/color'
+import color, { red } from '../../helpers/color'
 
 import Github from './Github'
 import GithubSwatch from './GithubSwatch'
@@ -16,8 +16,24 @@ test('Github renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Github onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Github onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const swatches = tree.find(Swatch);
+  swatches.at(0).childAt(0).simulate('click')
+
+  expect(changeSpy).toHaveBeenCalled()
+})
+
 test('Github with onSwatchHover events correctly', () => {
-  const hoverSpy = jest.fn()
+  const hoverSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
   const tree = mount(
     <Github onSwatchHover={hoverSpy} />
   )

--- a/src/components/sketch/spec.js
+++ b/src/components/sketch/spec.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme';
-import { red } from '../../helpers/color'
+import color, { red } from '../../helpers/color'
 // import canvas from 'canvas'
 
 import Sketch from './Sketch'
@@ -25,8 +25,24 @@ test('Sketch renders correctly', () => {
 //   expect(tree).toMatchSnapshot()
 // })
 
+test('Sketch onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Sketch onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const swatches = tree.find(Swatch);
+  swatches.at(0).childAt(0).simulate('click')
+
+  expect(changeSpy).toHaveBeenCalled()
+})
+
 test('Sketch with onSwatchHover events correctly', () => {
-  const hoverSpy = jest.fn()
+  const hoverSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
   const tree = mount(
     <Sketch onSwatchHover={hoverSpy} />
   )

--- a/src/components/swatches/spec.js
+++ b/src/components/swatches/spec.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme';
-import { red } from '../../helpers/color'
+import color, { red } from '../../helpers/color'
 
 import Swatches from './Swatches'
 import SwatchesColor from './SwatchesColor'
@@ -17,8 +17,24 @@ test('Swatches renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Swatches onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Swatches onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const swatches = tree.find(Swatch);
+  swatches.at(0).childAt(0).simulate('click')
+
+  expect(changeSpy).toHaveBeenCalled()
+})
+
 test('Swatches with onSwatchHover events correctly', () => {
-  const hoverSpy = jest.fn()
+  const hoverSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
   const tree = mount(
     <Swatches onSwatchHover={hoverSpy} />
   )

--- a/src/components/twitter/spec.js
+++ b/src/components/twitter/spec.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme';
-import { red } from '../../helpers/color'
+import color, { red } from '../../helpers/color'
 
 import Twitter from './Twitter'
 import { Swatch } from '../common'
@@ -29,11 +29,26 @@ test('Twitter `triangle="top-right"`', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Twitter onChange events correctly', () => {
+  const changeSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
+  const tree = mount(
+    <Twitter { ...red } onChange={changeSpy} />
+  )
+  expect(changeSpy).toHaveBeenCalledTimes(0)
+  const swatches = tree.find(Swatch);
+  swatches.at(0).childAt(0).simulate('click')
+
+  expect(changeSpy).toHaveBeenCalled()
+})
 
 test('Twitter with onSwatchHover events correctly', () => {
-  const hoverSpy = jest.fn()
+  const hoverSpy = jest.fn((data) => {
+    expect(color.simpleCheckForValidColor(data)).toBeTruthy()
+  })
   const tree = mount(
-    <Twitter onSwatchHover={hoverSpy} />
+    <Twitter { ...red } onSwatchHover={hoverSpy} />
   )
   expect(hoverSpy).toHaveBeenCalledTimes(0)
   const swatches = tree.find(Swatch);


### PR DESCRIPTION
Makes it so that a color object is handed to `onSwatchHover`, rather than a plain hex.

Sorry for overlooking this! I know that this will be a breaking change, but hopefully catching in < 48 hours will make it okay to release this to be consistent with `onChange` api.

I added a bunch of tests for `onChange` while I was at it. 