### PR TITLE
Changed string refs to function refs.

### DIFF
--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -247,7 +247,7 @@ export class ChromeFields extends React.Component {
       <div style={ styles.wrap } className="flexbox-fix">
         { fields }
         <div style={ styles.toggle }>
-          <div style={ styles.icon } onClick={ this.toggleViews } ref="icon">
+          <div style={ styles.icon } onClick={ this.toggleViews } ref={icon => this.icon = icon}>
             <svg
               style={ styles.svg }
               viewBox="0 0 24 24"
@@ -256,12 +256,12 @@ export class ChromeFields extends React.Component {
               onMouseOut={ this.hideHighlight }
             >
               <path
-                ref="iconUp"
+                ref={iconUp => this.iconUp = iconUp}
                 fill="#333"
                 d="M12,5.83L15.17,9L16.58,7.59L12,3L7.41,7.59L8.83,9L12,5.83Z"
               />
               <path
-                ref="iconDown"
+                ref={iconDown => this.iconDown = iconDown}
                 fill="#333"
                 d="M12,18.17L8.83,15L7.42,16.41L12,21L16.59,16.41L15.17,15Z"
               />

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -10,7 +10,7 @@ export class Alpha extends (PureComponent || Component) {
   }
 
   handleChange = (e, skip) => {
-    const change = alpha.calculateChange(e, skip, this.props, this.refs.container)
+    const change = alpha.calculateChange(e, skip, this.props, this.container)
     change && this.props.onChange && this.props.onChange(change, e)
   }
 
@@ -93,7 +93,7 @@ export class Alpha extends (PureComponent || Component) {
         <div style={ styles.gradient } />
         <div
           style={ styles.container }
-          ref="container"
+          ref={container => this.container = container}
           onMouseDown={ this.handleMouseDown }
           onTouchMove={ this.handleChange }
           onTouchStart={ this.handleChange }

--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -12,7 +12,7 @@ export class EditableInput extends (PureComponent || Component) {
   }
 
   componentWillReceiveProps(nextProps) {
-    const input = this.refs.input
+    const input = this.input
     if (nextProps.value !== this.state.value) {
       if (input === document.activeElement) {
         this.setState({ blurValue: String(nextProps.value).toUpperCase() })
@@ -123,7 +123,7 @@ export class EditableInput extends (PureComponent || Component) {
       <div style={ styles.wrap }>
         <input
           style={ styles.input }
-          ref="input"
+          ref={input => this.input = input}
           value={ this.state.value }
           onKeyDown={ this.handleKeyDown }
           onChange={ this.handleChange }

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -8,7 +8,7 @@ export class Hue extends (PureComponent || Component) {
   }
 
   handleChange = (e, skip) => {
-    const change = hue.calculateChange(e, skip, this.props, this.refs.container)
+    const change = hue.calculateChange(e, skip, this.props, this.container)
     change && this.props.onChange && this.props.onChange(change, e)
   }
 
@@ -72,7 +72,7 @@ export class Hue extends (PureComponent || Component) {
       <div style={ styles.hue }>
         <div
           style={ styles.container }
-          ref="container"
+          ref={container => this.container = container}
           onMouseDown={ this.handleMouseDown }
           onTouchMove={ this.handleChange }
           onTouchStart={ this.handleChange }

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -19,7 +19,7 @@ export class Saturation extends (PureComponent || Component) {
   handleChange = (e, skip) => {
     this.props.onChange && this.throttle(
       this.props.onChange,
-      saturation.calculateChange(e, skip, this.props, this.refs.container),
+      saturation.calculateChange(e, skip, this.props, this.container),
       e
     )
   }
@@ -85,7 +85,7 @@ export class Saturation extends (PureComponent || Component) {
     return (
       <div
         style={ styles.color }
-        ref="container"
+        ref={container => this.container = container}
         onMouseDown={ this.handleMouseDown }
         onTouchMove={ this.handleChange }
         onTouchStart={ this.handleChange }

--- a/test/chrome/ChromeFields.test.js
+++ b/test/chrome/ChromeFields.test.js
@@ -47,7 +47,7 @@ describe('ChromeFields', () => {
 
   it('should shuffle through view value when clicking on toggle', () => {
     const ChromeFields = TestUtils.renderIntoDocument(<ChromeFieldsComponent { ...props } />)
-    const toggle = ChromeFields.refs.icon
+    const toggle = ChromeFields.icon
 
     expect(ChromeFields.state.view).to.eql('hex')
     TestUtils.Simulate.click(toggle)


### PR DESCRIPTION
Fixes https://github.com/casesandberg/react-color/issues/374

This is not a breaking change unless someone is accessing the private refs of the components. I couldn't just simulate the old this.refs because react freezes that object.