### PR TITLE
Allow Github.js receive width props as percentage

### DIFF
--- a/src/components/block/Block.js
+++ b/src/components/block/Block.js
@@ -98,7 +98,7 @@ export const Block = ({ onChange, onSwatchHover, hex, colors, width, triangle })
 }
 
 Block.propTypes = {
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colors: PropTypes.arrayOf(PropTypes.string),
   triangle: PropTypes.oneOf(['top', 'hide']),
 }

--- a/src/components/circle/Circle.js
+++ b/src/components/circle/Circle.js
@@ -41,7 +41,7 @@ export const Circle = ({ width, onChange, onSwatchHover, colors, hex, circleSize
 }
 
 Circle.propTypes = {
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   circleSize: PropTypes.number,
   circleSpacing: PropTypes.number,
 }

--- a/src/components/github/Github.js
+++ b/src/components/github/Github.js
@@ -97,7 +97,7 @@ export const Github = ({ width, colors, onChange, onSwatchHover, triangle }) => 
 }
 
 Github.propTypes = {
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colors: PropTypes.arrayOf(PropTypes.string),
   triangle: PropTypes.oneOf(['hide', 'top-left', 'top-right']),
 }

--- a/src/components/sketch/Sketch.js
+++ b/src/components/sketch/Sketch.js
@@ -136,7 +136,7 @@ export const Sketch = ({ width, rgb, hex, hsv, hsl, onChange, onSwatchHover,
 
 Sketch.propTypes = {
   disableAlpha: PropTypes.bool,
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   presetColors: PropTypes.arrayOf(PropTypes.string),
 }
 

--- a/src/components/swatches/Swatches.js
+++ b/src/components/swatches/Swatches.js
@@ -59,8 +59,8 @@ export const Swatches = ({ width, height, onChange, onSwatchHover, colors, hex }
 }
 
 Swatches.propTypes = {
-  width: PropTypes.number,
-  height: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colors: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
 }
 

--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -150,7 +150,7 @@ export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle 
 }
 
 Twitter.propTypes = {
-  width: PropTypes.number,
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   triangle: PropTypes.oneOf(['hide', 'top-left', 'top-right']),
   colors: PropTypes.arrayOf(PropTypes.string),
 }


### PR DESCRIPTION
I am receiving warnings about width props just allow numbers, but I want to pass it as percentage ('100%')...
Actually, the behavior works as expected, but the warnings is sucks.