### PR TITLE
fix hsla fields when no data changed and on blured

### DIFF
--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -69,8 +69,8 @@ export class ChromeFields extends React.Component {
     } else if (data.h || data.s || data.l) {
       this.props.onChange({
         h: data.h || this.props.hsl.h,
-        s: (data.s && data.s) || this.props.hsl.s,
-        l: (data.l && data.l) || this.props.hsl.l,
+        s: Number((data.s && data.s) || this.props.hsl.s),
+        l: Number((data.l && data.l) || this.props.hsl.l),
         source: 'hsl',
       }, e)
     }

--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -17,7 +17,7 @@ export class EditableInput extends (PureComponent || Component) {
       if (input === document.activeElement) {
         this.setState({ blurValue: String(nextProps.value).toUpperCase() })
       } else {
-        this.setState({ value: String(nextProps.value).toUpperCase() })
+        this.setState({ value: String(nextProps.value).toUpperCase(), blurValue: !this.state.blurValue && String(nextProps.value).toUpperCase() })
       }
     }
   }


### PR DESCRIPTION
when you go to ChromePicker and switch to hsla and focus on some field without making any changes blur on it then the input field updates with the wrong data. 