### PR TITLE
Add react-color dependency in example apps

### DIFF
--- a/examples/basic-positioning/package.json
+++ b/examples/basic-positioning/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "react": "^15.6.1",
+    "react-color": "latest",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.12"
   },

--- a/examples/basic-toggle-open-closed/package.json
+++ b/examples/basic-toggle-open-closed/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "react": "^15.6.1",
+    "react-color": "latest",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.12"
   },

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "react": "^15.6.1",
+    "react-color": "latest",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.12"
   },

--- a/examples/custom-picker/package.json
+++ b/examples/custom-picker/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "react": "^15.6.1",
+    "react-color": "latest",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.12"
   },

--- a/examples/custom-pointer/package.json
+++ b/examples/custom-pointer/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "react": "^15.6.1",
+    "react-color": "latest",
     "react-dom": "^15.6.1",
     "react-scripts": "1.0.12"
   },

--- a/examples/with-redux/package.json
+++ b/examples/with-redux/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "react": "^15.6.1",
+    "react-color": "latest",
     "react-dom": "^15.6.1",
     "react-redux": "^5.0.6",
     "react-scripts": "1.0.12",


### PR DESCRIPTION
This will allow one to just run `npm install` and `npm start` to run individual examples.