### PR TITLE
Sketch: Use a complex key for preset colors

### DIFF
--- a/src/components/sketch/SketchPresetColors.js
+++ b/src/components/sketch/SketchPresetColors.js
@@ -47,8 +47,9 @@ export const SketchPresetColors = ({ colors, onClick = () => {}, onSwatchHover }
         const c = typeof colorObjOrString === 'string'
           ? { color: colorObjOrString }
           : colorObjOrString
+        const key = `${c.color}${c.title || ''}`
         return (
-          <div key={ c.color } style={ styles.swatchWrap }>
+          <div key={ key } style={ styles.swatchWrap }>
             <Swatch
               { ...c }
               style={ styles.swatch }


### PR DESCRIPTION
Allows for multiple presets with the same color but different titles.