### PR TITLE
Add styles prop to all components

### DIFF
--- a/docs/documentation/03.05-customStyles.md
+++ b/docs/documentation/03.05-customStyles.md
@@ -1,0 +1,26 @@
+---
+id: api-customStyles
+title: Customizing Styles
+---
+Pass a `styles` object to override the default inline styles.
+
+```
+import React from 'react'
+import { SketchPicker } from 'react-color'
+
+export default class Component extends React.Component {
+  render() {
+    return (
+      <SketchPicker
+        styles={{
+          default: {
+            picker: { // See the individual picker source for which keys to use
+              boxShadow: 'none',
+            },
+          },
+        }}
+      />
+    )
+  }
+}
+```

--- a/src/components/block/Block.js
+++ b/src/components/block/Block.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Checkboard } from '../common'
 import BlockSwatches from './BlockSwatches'
 
 export const Block = ({ onChange, onSwatchHover, hex, colors, width, triangle,
-  className = '' }) => {
+  styles: passedStyles = {}, className = '' }) => {
   const transparent = hex === 'transparent'
   const handleChange = (hexCode, e) => {
     color.isValidHex(hexCode) && onChange({
@@ -16,7 +17,7 @@ export const Block = ({ onChange, onSwatchHover, hex, colors, width, triangle,
     }, e)
   }
 
-  const styles = reactCSS({
+  const styles = reactCSS(merge({
     'default': {
       card: {
         width,
@@ -71,7 +72,7 @@ export const Block = ({ onChange, onSwatchHover, hex, colors, width, triangle,
         display: 'none',
       },
     },
-  }, { 'hide-triangle': triangle === 'hide' })
+  }, passedStyles), { 'hide-triangle': triangle === 'hide' })
 
   return (
     <div style={ styles.card } className={ `block-picker ${ className }` }>
@@ -102,6 +103,7 @@ Block.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colors: PropTypes.arrayOf(PropTypes.string),
   triangle: PropTypes.oneOf(['top', 'hide']),
+  styles: PropTypes.object,
 }
 
 Block.defaultProps = {
@@ -109,6 +111,7 @@ Block.defaultProps = {
   colors: ['#D9E3F0', '#F47373', '#697689', '#37D67A', '#2CCCE4', '#555555',
     '#dce775', '#ff8a65', '#ba68c8'],
   triangle: 'top',
+  styles: {},
 }
 
 export default ColorWrap(Block)

--- a/src/components/block/spec.js
+++ b/src/components/block/spec.js
@@ -57,3 +57,9 @@ test('BlockSwatches renders correctly', () => {
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
+test('Block renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Block styles={{ default: { card: { boxShadow: 'none' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('none')
+})

--- a/src/components/chrome/Chrome.js
+++ b/src/components/chrome/Chrome.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Saturation, Hue, Alpha, Checkboard } from '../common'
 import ChromeFields from './ChromeFields'
@@ -8,8 +9,8 @@ import ChromePointer from './ChromePointer'
 import ChromePointerCircle from './ChromePointerCircle'
 
 export const Chrome = ({ onChange, disableAlpha, rgb, hsl, hsv, hex, renderers,
-  className = '' }) => {
-  const styles = reactCSS({
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       picker: {
         background: '#fff',
@@ -88,7 +89,7 @@ export const Chrome = ({ onChange, disableAlpha, rgb, hsl, hsv, hex, renderers,
         marginTop: '0px',
       },
     },
-  }, { disableAlpha })
+  }, passedStyles), { disableAlpha })
 
   return (
     <div style={ styles.picker } className={ `chrome-picker ${ className }` }>
@@ -144,10 +145,12 @@ export const Chrome = ({ onChange, disableAlpha, rgb, hsl, hsv, hex, renderers,
 
 Chrome.propTypes = {
   disableAlpha: PropTypes.bool,
+  styles: PropTypes.object,
 }
 
 Chrome.defaultProps = {
   disableAlpha: false,
+  styles: {},
 }
 
 export default ColorWrap(Chrome)

--- a/src/components/chrome/spec.js
+++ b/src/components/chrome/spec.js
@@ -68,3 +68,10 @@ test('ChromePointerCircle renders correctly', () => {
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+test('Chrome renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Chrome styles={{ default: { picker: { boxShadow: 'none' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('none')
+})

--- a/src/components/circle/Circle.js
+++ b/src/components/circle/Circle.js
@@ -2,14 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
 import map from 'lodash/map'
+import merge from 'lodash/merge'
 import * as material from 'material-colors'
 
 import { ColorWrap } from '../common'
 import CircleSwatch from './CircleSwatch'
 
 export const Circle = ({ width, onChange, onSwatchHover, colors, hex, circleSize,
-  circleSpacing, className = '' }) => {
-  const styles = reactCSS({
+  styles: passedStyles = {}, circleSpacing, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       card: {
         width,
@@ -19,7 +20,7 @@ export const Circle = ({ width, onChange, onSwatchHover, colors, hex, circleSize
         marginBottom: -circleSpacing,
       },
     },
-  })
+  }, passedStyles))
 
   const handleChange = (hexCode, e) => onChange({ hex: hexCode, source: 'hex' }, e)
 
@@ -44,6 +45,7 @@ Circle.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   circleSize: PropTypes.number,
   circleSpacing: PropTypes.number,
+  styles: PropTypes.object,
 }
 
 Circle.defaultProps = {
@@ -56,6 +58,7 @@ Circle.defaultProps = {
     material.green['500'], material.lightGreen['500'], material.lime['500'],
     material.yellow['500'], material.amber['500'], material.orange['500'],
     material.deepOrange['500'], material.brown['500'], material.blueGrey['500']],
+  styles: {},
 }
 
 export default ColorWrap(Circle)

--- a/src/components/circle/spec.js
+++ b/src/components/circle/spec.js
@@ -45,6 +45,13 @@ test('Circle with onSwatchHover events correctly', () => {
   expect(hoverSpy).toHaveBeenCalled()
 })
 
+test('Circle renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Circle styles={{ default: { card: { boxShadow: 'none' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('none')
+})
+
 test('CircleSwatch renders correctly', () => {
   const tree = renderer.create(
     <CircleSwatch />,

--- a/src/components/common/Raised.js
+++ b/src/components/common/Raised.js
@@ -1,9 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 
-export const Raised = ({ zDepth, radius, background, children }) => {
-  const styles = reactCSS({
+export const Raised = ({ zDepth, radius, background, children,
+  styles: passedStyles = {} }) => {
+  const styles = reactCSS(merge({
     'default': {
       wrap: {
         position: 'relative',
@@ -60,7 +62,7 @@ export const Raised = ({ zDepth, radius, background, children }) => {
         borderRadius: '50%',
       },
     },
-  }, { 'zDepth-1': zDepth === 1 })
+  }, passedStyles), { 'zDepth-1': zDepth === 1 })
 
   return (
     <div style={ styles.wrap }>
@@ -76,12 +78,14 @@ Raised.propTypes = {
   background: PropTypes.string,
   zDepth: PropTypes.oneOf([0, 1, 2, 3, 4, 5]),
   radius: PropTypes.number,
+  styles: PropTypes.object,
 }
 
 Raised.defaultProps = {
   background: '#fff',
   zDepth: 1,
   radius: 2,
+  styles: {},
 }
 
 export default Raised

--- a/src/components/compact/Compact.js
+++ b/src/components/compact/Compact.js
@@ -2,14 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
 import map from 'lodash/map'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, Raised } from '../common'
 import CompactColor from './CompactColor'
 import CompactFields from './CompactFields'
 
-export const Compact = ({ onChange, onSwatchHover, colors, hex, rgb, className = '' }) => {
-  const styles = reactCSS({
+export const Compact = ({ onChange, onSwatchHover, colors, hex, rgb,
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       Compact: {
         background: '#f6f6f6',
@@ -25,7 +27,7 @@ export const Compact = ({ onChange, onSwatchHover, colors, hex, rgb, className =
         clear: 'both',
       },
     },
-  })
+  }, passedStyles))
 
   const handleChange = (data, e) => {
     if (data.hex) {
@@ -39,10 +41,10 @@ export const Compact = ({ onChange, onSwatchHover, colors, hex, rgb, className =
   }
 
   return (
-    <Raised style={ styles.Compact }>
+    <Raised style={ styles.Compact } styles={ passedStyles }>
       <div style={ styles.compact } className={ `compact-picker ${ className }` }>
         <div>
-          { map(colors, c => (
+          { map(colors, (c) => (
             <CompactColor
               key={ c }
               color={ c }
@@ -61,6 +63,7 @@ export const Compact = ({ onChange, onSwatchHover, colors, hex, rgb, className =
 
 Compact.propTypes = {
   colors: PropTypes.arrayOf(PropTypes.string),
+  styles: PropTypes.object,
 }
 
 Compact.defaultProps = {
@@ -71,6 +74,7 @@ Compact.defaultProps = {
     '#000000', '#666666', '#B3B3B3', '#9F0500', '#C45100', '#FB9E00',
     '#808900', '#194D33', '#0C797D', '#0062B1', '#653294', '#AB149E',
   ],
+  styles: {},
 }
 
 export default ColorWrap(Compact)

--- a/src/components/compact/spec.js
+++ b/src/components/compact/spec.js
@@ -65,3 +65,10 @@ test('CompactFields renders correctly', () => {
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+test('Compact renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Compact { ...red } styles={{ default: { wrap: { boxShadow: '0 0 10px red' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('0 0 10px red')
+})

--- a/src/components/github/Github.js
+++ b/src/components/github/Github.js
@@ -2,13 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
 import map from 'lodash/map'
+import merge from 'lodash/merge'
 
 import { ColorWrap } from '../common'
 import GithubSwatch from './GithubSwatch'
 
 export const Github = ({ width, colors, onChange, onSwatchHover, triangle,
-  className = '' }) => {
-  const styles = reactCSS({
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       card: {
         width,
@@ -84,7 +85,7 @@ export const Github = ({ width, colors, onChange, onSwatchHover, triangle,
         transform: 'rotate(180deg)',
       },
     },
-  }, {
+  }, passedStyles), {
     'hide-triangle': triangle === 'hide',
     'top-left-triangle': triangle === 'top-left',
     'top-right-triangle': triangle === 'top-right',
@@ -114,6 +115,7 @@ Github.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colors: PropTypes.arrayOf(PropTypes.string),
   triangle: PropTypes.oneOf(['hide', 'top-left', 'top-right', 'bottom-left', 'bottom-right']),
+  styles: PropTypes.object,
 }
 
 Github.defaultProps = {
@@ -121,6 +123,7 @@ Github.defaultProps = {
   colors: ['#B80000', '#DB3E00', '#FCCB00', '#008B02', '#006B76', '#1273DE', '#004DCF', '#5300EB',
     '#EB9694', '#FAD0C3', '#FEF3BD', '#C1E1C5', '#BEDADC', '#C4DEF6', '#BED3F3', '#D4C4FB'],
   triangle: 'top-left',
+  styles: {},
 }
 
 export default ColorWrap(Github)

--- a/src/components/github/spec.js
+++ b/src/components/github/spec.js
@@ -58,6 +58,13 @@ test('Github `triangle="top-right"`', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Github renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Github { ...red } styles={{ default: { card: { boxShadow: '0 0 10px red' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('0 0 10px red')
+})
+
 test('GithubSwatch renders correctly', () => {
   const tree = renderer.create(
     <GithubSwatch color="#333" />,

--- a/src/components/hue/Hue.js
+++ b/src/components/hue/Hue.js
@@ -1,12 +1,14 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Hue } from '../common'
 import HuePointer from './HuePointer'
 
 export const HuePicker = ({ width, height, onChange, hsl, direction, pointer,
-  className = '' }) => {
-  const styles = reactCSS({
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       picker: {
         position: 'relative',
@@ -17,7 +19,7 @@ export const HuePicker = ({ width, height, onChange, hsl, direction, pointer,
         radius: '2px',
       },
     },
-  })
+  }, passedStyles))
 
   // Overwrite to provide pure hue color
   const handleChange = data => onChange({ a: 1, h: data.h, l: 0.5, s: 1 })
@@ -35,11 +37,15 @@ export const HuePicker = ({ width, height, onChange, hsl, direction, pointer,
   )
 }
 
+HuePicker.propTypes = {
+  styles: PropTypes.object,
+}
 HuePicker.defaultProps = {
   width: '316px',
   height: '16px',
   direction: 'horizontal',
   pointer: HuePointer,
+  styles: {},
 }
 
 export default ColorWrap(HuePicker)

--- a/src/components/hue/spec.js
+++ b/src/components/hue/spec.js
@@ -21,6 +21,13 @@ test('Hue renders vertically', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Hue renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Hue { ...red } styles={{ default: { picker: { boxShadow: '0 0 10px red' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('0 0 10px red')
+})
+
 test('HuePointer renders correctly', () => {
   const tree = renderer.create(
     <HuePointer />,

--- a/src/components/material/Material.js
+++ b/src/components/material/Material.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Raised } from '../common'
 
-export const Material = ({ onChange, hex, rgb, className = '' }) => {
-  const styles = reactCSS({
+export const Material = ({ onChange, hex, rgb,
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       material: {
         width: '98px',
@@ -72,7 +74,7 @@ export const Material = ({ onChange, hex, rgb, className = '' }) => {
         paddingRight: '10px',
       },
     },
-  })
+  }, passedStyles))
 
   const handleChange = (data, e) => {
     if (data.hex) {
@@ -91,7 +93,7 @@ export const Material = ({ onChange, hex, rgb, className = '' }) => {
   }
 
   return (
-    <Raised>
+    <Raised styles={ passedStyles }>
       <div style={ styles.material } className={ `material-picker ${ className }` }>
         <EditableInput
           style={{ wrap: styles.HEXwrap, input: styles.HEXinput, label: styles.HEXlabel }}

--- a/src/components/material/spec.js
+++ b/src/components/material/spec.js
@@ -12,3 +12,11 @@ test('Material renders correctly', () => {
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
+
+test('Material renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Material { ...red } styles={{ default: { wrap: { boxShadow: '0 0 10px red' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('0 0 10px red')
+})
+

--- a/src/components/photoshop/Photoshop.js
+++ b/src/components/photoshop/Photoshop.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Saturation, Hue } from '../common'
 import PhotoshopFields from './PhotoshopFields'
@@ -19,8 +20,11 @@ export class Photoshop extends React.Component {
   }
 
   render() {
-    const { className = '' } = this.props
-    const styles = reactCSS({
+    const { 
+      styles: passedStyles = {},
+      className = '',
+    } = this.props
+    const styles = reactCSS(merge({
       'default': {
         picker: {
           background: '#DCDCDC',
@@ -75,7 +79,7 @@ export class Photoshop extends React.Component {
           marginLeft: '20px',
         },
       },
-    })
+    }, passedStyles))
 
     return (
       <div style={ styles.picker } className={ `photoshop-picker ${ className }` }>
@@ -126,10 +130,12 @@ export class Photoshop extends React.Component {
 
 Photoshop.propTypes = {
   header: PropTypes.string,
+  styles: PropTypes.object,
 }
 
 Photoshop.defaultProps = {
   header: 'Color Picker',
+  styles: {},
 }
 
 export default ColorWrap(Photoshop)

--- a/src/components/photoshop/spec.js
+++ b/src/components/photoshop/spec.js
@@ -18,6 +18,13 @@ test('Photoshop renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Photoshop renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Photoshop { ...red } styles={{ default: { picker: { boxShadow: '0 0 10px red' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('0 0 10px red')
+})
+
 test('PhotoshopButton renders correctly', () => {
   const tree = renderer.create(
     <PhotoshopButton label="accept" onClick={ () => {} } />,

--- a/src/components/sketch/Sketch.js
+++ b/src/components/sketch/Sketch.js
@@ -1,14 +1,15 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Saturation, Hue, Alpha, Checkboard } from '../common'
 import SketchFields from './SketchFields'
 import SketchPresetColors from './SketchPresetColors'
 
 export const Sketch = ({ width, rgb, hex, hsv, hsl, onChange, onSwatchHover,
-  disableAlpha, presetColors, renderers, className = '' }) => {
-  const styles = reactCSS({
+  disableAlpha, presetColors, renderers, styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       picker: {
         width,
@@ -69,6 +70,7 @@ export const Sketch = ({ width, rgb, hex, hsv, hsl, onChange, onSwatchHover,
         radius: '2px',
         shadow: 'inset 0 0 0 1px rgba(0,0,0,.15), inset 0 0 4px rgba(0,0,0,.25)',
       },
+      ...passedStyles,
     },
     'disableAlpha': {
       color: {
@@ -81,7 +83,7 @@ export const Sketch = ({ width, rgb, hex, hsv, hsl, onChange, onSwatchHover,
         display: 'none',
       },
     },
-  }, { disableAlpha })
+  }, passedStyles), { disableAlpha })
 
   return (
     <div style={ styles.picker } className={ `sketch-picker ${ className }` }>
@@ -137,11 +139,13 @@ export const Sketch = ({ width, rgb, hex, hsv, hsl, onChange, onSwatchHover,
 Sketch.propTypes = {
   disableAlpha: PropTypes.bool,
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  styles: PropTypes.object,
 }
 
 Sketch.defaultProps = {
   disableAlpha: false,
   width: 200,
+  styles: {},
   presetColors: ['#D0021B', '#F5A623', '#F8E71C', '#8B572A', '#7ED321', '#417505',
     '#BD10E0', '#9013FE', '#4A90E2', '#50E3C2', '#B8E986', '#000000',
     '#4A4A4A', '#9B9B9B', '#FFFFFF'],

--- a/src/components/sketch/spec.js
+++ b/src/components/sketch/spec.js
@@ -53,6 +53,13 @@ test('Sketch with onSwatchHover events correctly', () => {
   expect(hoverSpy).toHaveBeenCalled()
 })
 
+test('Sketch renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Sketch styles={{ default: { picker: { boxShadow: 'none' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('none')
+})
+
 test('SketchFields renders correctly', () => {
   const tree = renderer.create(
     <SketchFields { ...red } />,

--- a/src/components/sketch/story.js
+++ b/src/components/sketch/story.js
@@ -13,3 +13,18 @@ storiesOf('Pickers', module)
       }) }
     </SyncColorField>
   ))
+  .add('SketchPicker Custom Styles', () => (
+    <SyncColorField component={ Sketch }>
+      { renderWithKnobs(Sketch, {
+        styles: {
+          default: {
+            picker: {
+              boxShadow: 'none',
+            },
+          }
+        }
+      }, null, {
+        width: { range: true, min: 140, max: 500, step: 1 },
+      }) }
+    </SyncColorField>
+  ))

--- a/src/components/slider/Slider.js
+++ b/src/components/slider/Slider.js
@@ -1,12 +1,15 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Hue } from '../common'
 import SliderSwatches from './SliderSwatches'
 import SliderPointer from './SliderPointer'
 
-export const Slider = ({ hsl, onChange, pointer, className = '' }) => {
-  const styles = reactCSS({
+export const Slider = ({ hsl, onChange, pointer,
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       hue: {
         height: '12px',
@@ -16,10 +19,10 @@ export const Slider = ({ hsl, onChange, pointer, className = '' }) => {
         radius: '2px',
       },
     },
-  })
+  }, passedStyles))
 
   return (
-    <div className={ `slider-picker ${ className }` }>
+    <div style={ styles.wrap || '' } className={ `slider-picker ${ className }` }>
       <div style={ styles.hue }>
         <Hue
           style={ styles.Hue }
@@ -35,8 +38,12 @@ export const Slider = ({ hsl, onChange, pointer, className = '' }) => {
   )
 }
 
+Slider.propTypes = {
+  styles: PropTypes.object,
+}
 Slider.defaultProps = {
   pointer: SliderPointer,
+  styles: {},
 }
 
 export default ColorWrap(Slider)

--- a/src/components/slider/__snapshots__/spec.js.snap
+++ b/src/components/slider/__snapshots__/spec.js.snap
@@ -3,6 +3,7 @@
 exports[`Slider renders correctly 1`] = `
 <div
   className="slider-picker "
+  style=""
 >
   <div
     style={

--- a/src/components/slider/spec.js
+++ b/src/components/slider/spec.js
@@ -16,6 +16,14 @@ test('Slider renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Slider renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Slider styles={{ default: { wrap: { boxShadow: 'none' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('none')
+})
+
+
 test('SliderPointer renders correctly', () => {
   const tree = renderer.create(
     <SliderPointer />,

--- a/src/components/swatches/Swatches.js
+++ b/src/components/swatches/Swatches.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
 import map from 'lodash/map'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 import * as material from 'material-colors'
 
@@ -9,8 +10,8 @@ import { ColorWrap, Raised } from '../common'
 import SwatchesGroup from './SwatchesGroup'
 
 export const Swatches = ({ width, height, onChange, onSwatchHover, colors, hex,
-  className = '' }) => {
-  const styles = reactCSS({
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       picker: {
         width,
@@ -27,7 +28,7 @@ export const Swatches = ({ width, height, onChange, onSwatchHover, colors, hex,
         clear: 'both',
       },
     },
-  })
+  }, passedStyles))
 
   const handleChange = (data, e) => {
     color.isValidHex(data) && onChange({
@@ -62,6 +63,7 @@ Swatches.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colors: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
+  styles: PropTypes.object,
 }
 
 /* eslint-disable max-len */
@@ -89,6 +91,7 @@ Swatches.defaultProps = {
     [material.blueGrey['900'], material.blueGrey['700'], material.blueGrey['500'], material.blueGrey['300'], material.blueGrey['100']],
     ['#000000', '#525252', '#969696', '#D9D9D9', '#FFFFFF'],
   ],
+  styles: {},
 }
 
 export default ColorWrap(Swatches)

--- a/src/components/swatches/spec.js
+++ b/src/components/swatches/spec.js
@@ -17,6 +17,13 @@ test('Swatches renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Swatches renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Swatches hex={ red.hex } colors={ [['#fff'], ['#333']] } styles={{ default: { picker: { boxShadow: '0 0 10px red' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('0 0 10px red')
+})
+
 test('Swatches onChange events correctly', () => {
   const changeSpy = jest.fn((data) => {
     expect(color.simpleCheckForValidColor(data)).toBeTruthy()

--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -2,13 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
 import map from 'lodash/map'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Swatch } from '../common'
 
 export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
-  className = '' }) => {
-  const styles = reactCSS({
+  styles: passedStyles = {}, className = '' }) => {
+  const styles = reactCSS(merge({
     'default': {
       card: {
         width,
@@ -104,7 +105,7 @@ export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
         right: '12px',
       },
     },
-  }, {
+  }, passedStyles), {
     'hide-triangle': triangle === 'hide',
     'top-left-triangle': triangle === 'top-left',
     'top-right-triangle': triangle === 'top-right',
@@ -154,6 +155,7 @@ Twitter.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   triangle: PropTypes.oneOf(['hide', 'top-left', 'top-right']),
   colors: PropTypes.arrayOf(PropTypes.string),
+  styles: PropTypes.object,
 }
 
 Twitter.defaultProps = {
@@ -161,6 +163,7 @@ Twitter.defaultProps = {
   colors: ['#FF6900', '#FCB900', '#7BDCB5', '#00D084', '#8ED1FC', '#0693E3',
     '#ABB8C3', '#EB144C', '#F78DA7', '#9900EF'],
   triangle: 'top-left',
+  styles: {},
 }
 
 export default ColorWrap(Twitter)

--- a/src/components/twitter/spec.js
+++ b/src/components/twitter/spec.js
@@ -15,6 +15,13 @@ test('Twitter renders correctly', () => {
   expect(tree).toMatchSnapshot()
 })
 
+test('Material renders custom styles correctly', () => {
+  const tree = renderer.create(
+    <Twitter { ...red } styles={{ default: { card: { boxShadow: '0 0 10px red' } } }} />,
+  ).toJSON()
+  expect(tree.props.style.boxShadow).toBe('0 0 10px red')
+})
+
 test('Twitter `triangle="hide"`', () => {
   const tree = renderer.create(
     <Twitter { ...red } triangle="hide" />,


### PR DESCRIPTION
Merge passed-in styles into reactCSS config for all components to allow for customizing styles.
Add tests.

Would be happy to add to the docs for this, but #446 is in my way.