### PR TITLE
Publish explicit files instead of blacklist to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-docs
-node_modules
-src
-test
-.babelrc

--- a/package.json
+++ b/package.json
@@ -89,6 +89,9 @@
     "webpack": "^1.11.0",
     "webpack-dev-server": "^1.10.1"
   },
+  "files": [
+    "lib"
+  ],
   "jest": {
     "rootDir": "src",
     "testRegex": "spec.js$"


### PR DESCRIPTION
Publish only the `/lib` directory using the [package.json#files](https://docs.npmjs.com/files/package.json#files) field instead of the .npmignore file.

## Files published before:

 |         Size | Filename           |
 |-------------:|--------------------|
 |           4K | .github/           |
 |          36B | .npmignore         |
 |          16K | .storybook/        |
 |         137B | .travis.yml        |
 |         3.1K | CODE_OF_CONDUCT.md |
 |         1.1K | LICENSE            |
 |         1.6K | README.md          |
 | **--> 1.7M** | examples/          |
 |         160B | lib/               |
 |         2.9K | package.json       |
 |         8.0K | scripts/           |
 |         971B | webpack.config.js  |
 |--------------|--------------------|
 |     **2.1M** | (total)            |

## Files published after:

 |     Size | Filename     |
 |---------:|--------------|
 |     1.1K | LICENSE      |
 |     1.6K | README.md    |
 |     372K | lib/         |
 |     2.9K | package.json |
 |----------|--------------|
 | **386K** | (total)      |
