### PR TITLE
add <selectedColor> support for Github & Twitter Picker

### DIFF
--- a/src/components/github/Github.js
+++ b/src/components/github/Github.js
@@ -5,92 +5,103 @@ import map from 'lodash/map'
 
 import { ColorWrap } from '../common'
 import GithubSwatch from './GithubSwatch'
+import color from '../../helpers/color'
 
-export const Github = ({ width, colors, onChange, onSwatchHover, triangle,
-  className = '' }) => {
-  const styles = reactCSS({
-    'default': {
-      card: {
-        width,
-        background: '#fff',
-        border: '1px solid rgba(0,0,0,0.2)',
-        boxShadow: '0 3px 12px rgba(0,0,0,0.15)',
-        borderRadius: '4px',
-        position: 'relative',
-        padding: '5px',
-        display: 'flex',
-        flexWrap: 'wrap',
+export const Github = ({
+  width,
+  hex,
+  colors,
+  onChange,
+  onSwatchHover,
+  triangle,
+  className = '',
+}) => {
+  const styles = reactCSS(
+    {
+      default: {
+        card: {
+          width,
+          background: '#fff',
+          border: '1px solid rgba(0,0,0,0.2)',
+          boxShadow: '0 3px 12px rgba(0,0,0,0.15)',
+          borderRadius: '4px',
+          position: 'relative',
+          padding: '5px',
+          display: 'flex',
+          flexWrap: 'wrap',
+        },
+        triangle: {
+          position: 'absolute',
+          border: '7px solid transparent',
+          borderBottomColor: '#fff',
+        },
+        triangleShadow: {
+          position: 'absolute',
+          border: '8px solid transparent',
+          borderBottomColor: 'rgba(0,0,0,0.15)',
+        },
       },
-      triangle: {
-        position: 'absolute',
-        border: '7px solid transparent',
-        borderBottomColor: '#fff',
+      'hide-triangle': {
+        triangle: {
+          display: 'none',
+        },
+        triangleShadow: {
+          display: 'none',
+        },
       },
-      triangleShadow: {
-        position: 'absolute',
-        border: '8px solid transparent',
-        borderBottomColor: 'rgba(0,0,0,0.15)',
+      'top-left-triangle': {
+        triangle: {
+          top: '-14px',
+          left: '10px',
+        },
+        triangleShadow: {
+          top: '-16px',
+          left: '9px',
+        },
+      },
+      'top-right-triangle': {
+        triangle: {
+          top: '-14px',
+          right: '10px',
+        },
+        triangleShadow: {
+          top: '-16px',
+          right: '9px',
+        },
+      },
+      'bottom-left-triangle': {
+        triangle: {
+          top: '35px',
+          left: '10px',
+          transform: 'rotate(180deg)',
+        },
+        triangleShadow: {
+          top: '37px',
+          left: '9px',
+          transform: 'rotate(180deg)',
+        },
+      },
+      'bottom-right-triangle': {
+        triangle: {
+          top: '35px',
+          right: '10px',
+          transform: 'rotate(180deg)',
+        },
+        triangleShadow: {
+          top: '37px',
+          right: '9px',
+          transform: 'rotate(180deg)',
+        },
       },
     },
-    'hide-triangle': {
-      triangle: {
-        display: 'none',
-      },
-      triangleShadow: {
-        display: 'none',
-      },
-    },
-    'top-left-triangle': {
-      triangle: {
-        top: '-14px',
-        left: '10px',
-      },
-      triangleShadow: {
-        top: '-16px',
-        left: '9px',
-      },
-    },
-    'top-right-triangle': {
-      triangle: {
-        top: '-14px',
-        right: '10px',
-      },
-      triangleShadow: {
-        top: '-16px',
-        right: '9px',
-      },
-    },
-    'bottom-left-triangle': {
-      triangle: {
-        top: '35px',
-        left: '10px',
-        transform: 'rotate(180deg)',
-      },
-      triangleShadow: {
-        top: '37px',
-        left: '9px',
-        transform: 'rotate(180deg)',
-      },
-    },
-    'bottom-right-triangle': {
-      triangle: {
-        top: '35px',
-        right: '10px',
-        transform: 'rotate(180deg)',
-      },
-      triangleShadow: {
-        top: '37px',
-        right: '9px',
-        transform: 'rotate(180deg)',
-      },
-    },
-  }, {
-    'hide-triangle': triangle === 'hide',
-    'top-left-triangle': triangle === 'top-left',
-    'top-right-triangle': triangle === 'top-right',
-    'bottom-left-triangle': triangle == 'bottom-left',
-    'bottom-right-triangle': triangle === 'bottom-right',
-  })
+    {
+      'hide-triangle': triangle === 'hide',
+      'top-left-triangle': triangle === 'top-left',
+      'top-right-triangle': triangle === 'top-right',
+      'bottom-left-triangle': triangle == 'bottom-left',
+      'bottom-right-triangle': triangle === 'bottom-right',
+    }
+  )
 
   const handleChange = (hex, e) => onChange({ hex, source: 'hex' }, e)
 
@@ -98,14 +109,22 @@ export const Github = ({ width, colors, onChange, onSwatchHover, triangle,
     <div style={ styles.card } className={ `github-picker ${ className }` }>
       <div style={ styles.triangleShadow } />
       <div style={ styles.triangle } />
-      { map(colors, c => (
-        <GithubSwatch
-          color={ c }
-          key={ c }
-          onClick={ handleChange }
-          onSwatchHover={ onSwatchHover }
-        />
-      )) }
+      {map(colors, (c) => {
+        const isActive =
+          c &&
+          hex &&
+          c.toLowerCase() === hex.toLowerCase()
+
+        return (
+          <GithubSwatch
+            color={ c }
+            key={ c }
+            active={ isActive }
+            onClick={ handleChange }
+            onSwatchHover={ onSwatchHover }
+          />
+        )
+      })}
     </div>
   )
 }
@@ -113,13 +132,36 @@ export const Github = ({ width, colors, onChange, onSwatchHover, triangle,
 Github.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   colors: PropTypes.arrayOf(PropTypes.string),
-  triangle: PropTypes.oneOf(['hide', 'top-left', 'top-right', 'bottom-left', 'bottom-right']),
+  triangle: PropTypes.oneOf([
+    'hide',
+    'top-left',
+    'top-right',
+    'bottom-left',
+    'bottom-right',
+  ]),
+  color: PropTypes.object.isRequired,
 }
 
 Github.defaultProps = {
   width: 200,
-  colors: ['#B80000', '#DB3E00', '#FCCB00', '#008B02', '#006B76', '#1273DE', '#004DCF', '#5300EB',
-    '#EB9694', '#FAD0C3', '#FEF3BD', '#C1E1C5', '#BEDADC', '#C4DEF6', '#BED3F3', '#D4C4FB'],
+  colors: [
+    '#B80000',
+    '#DB3E00',
+    '#FCCB00',
+    '#008B02',
+    '#006B76',
+    '#1273DE',
+    '#004DCF',
+    '#5300EB',
+    '#EB9694',
+    '#FAD0C3',
+    '#FEF3BD',
+    '#C1E1C5',
+    '#BEDADC',
+    '#C4DEF6',
+    '#BED3F3',
+    '#D4C4FB',
+  ],
   triangle: 'top-left',
 }
 

--- a/src/components/github/GithubSwatch.js
+++ b/src/components/github/GithubSwatch.js
@@ -2,8 +2,15 @@ import React from 'react'
 import reactCSS, { handleHover } from 'reactcss'
 
 import { Swatch } from '../common'
+import colorUtils from '../../helpers/color'
 
-export const GithubSwatch = ({ hover, color, onClick, onSwatchHover }) => {
+export const GithubSwatch = ({
+  hover,
+  color,
+  active,
+  onClick,
+  onSwatchHover,
+}) => {
   const hoverSwatch = {
     position: 'relative',
     zIndex: '2',
@@ -11,18 +18,45 @@ export const GithubSwatch = ({ hover, color, onClick, onSwatchHover }) => {
     boxShadow: '0 0 5px 2px rgba(0,0,0,0.25)',
   }
 
-  const styles = reactCSS({
-    'default': {
-      swatch: {
-        width: '25px',
-        height: '25px',
-        fontSize: '0',
+  const styles = reactCSS(
+    {
+      default: {
+        swatch: {
+          width: '25px',
+          height: '25px',
+          fontSize: '0',
+        },
+        check: {
+          fill: colorUtils.getContrastingColor(color),
+          display: 'none',
+        },
+      },
+      active: {
+        check: {
+          display: 'block',
+        },
+      },
+      hover: {
+        swatch: hoverSwatch,
+      },
+      'color-#FFFFFF': {
+        check: {
+          fill: '#333',
+        },
+      },
+      transparent: {
+        check: {
+          fill: '#333',
+        },
       },
     },
-    'hover': {
-      swatch: hoverSwatch,
-    },
-  }, { hover })
+    {
+      hover,
+      active,
+      'color-#FFFFFF': color === '#FFFFFF',
+      transparent: color === 'transparent',
+    }
+  )
 
   return (
     <div style={ styles.swatch }>
@@ -31,7 +65,13 @@ export const GithubSwatch = ({ hover, color, onClick, onSwatchHover }) => {
         onClick={ onClick }
         onHover={ onSwatchHover }
         focusStyle={ hoverSwatch }
-      />
+      >
+        <div style={ styles.check }>
+          <svg style={{ margin: '3px' }} viewBox="0 0 25 25">
+            <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+          </svg>
+        </div>
+      </Swatch>
     </div>
   )
 }

--- a/src/components/github/__snapshots__/spec.js.snap
+++ b/src/components/github/__snapshots__/spec.js.snap
@@ -77,7 +77,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#B80000"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -113,7 +135,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#DB3E00"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -149,7 +193,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#FCCB00"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -185,7 +251,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#008B02"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -221,7 +309,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#006B76"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -257,7 +367,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#1273DE"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -293,7 +425,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#004DCF"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -329,7 +483,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#5300EB"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -365,7 +541,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#EB9694"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -401,7 +599,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#FAD0C3"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -437,7 +657,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#FEF3BD"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -473,7 +715,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#C1E1C5"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -509,7 +773,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#BEDADC"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -545,7 +831,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#C4DEF6"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -581,7 +889,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#BED3F3"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -617,7 +947,29 @@ exports[`Github \`triangle="hide"\` 1`] = `
           }
           tabIndex={0}
           title="#D4C4FB"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -703,7 +1055,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#B80000"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -739,7 +1113,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#DB3E00"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -775,7 +1171,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#FCCB00"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -811,7 +1229,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#008B02"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -847,7 +1287,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#006B76"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -883,7 +1345,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#1273DE"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -919,7 +1403,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#004DCF"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -955,7 +1461,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#5300EB"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -991,7 +1519,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#EB9694"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1027,7 +1577,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#FAD0C3"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1063,7 +1635,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#FEF3BD"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1099,7 +1693,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#C1E1C5"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1135,7 +1751,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#BEDADC"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1171,7 +1809,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#C4DEF6"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1207,7 +1867,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#BED3F3"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1243,7 +1925,29 @@ exports[`Github \`triangle="top-right"\` 1`] = `
           }
           tabIndex={0}
           title="#D4C4FB"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1329,7 +2033,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#B80000"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1365,7 +2091,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#DB3E00"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1401,7 +2149,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#FCCB00"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1437,7 +2207,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#008B02"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1473,7 +2265,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#006B76"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1509,7 +2323,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#1273DE"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1545,7 +2381,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#004DCF"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1581,7 +2439,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#5300EB"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#fff",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1617,7 +2497,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#EB9694"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1653,7 +2555,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#FAD0C3"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1689,7 +2613,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#FEF3BD"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1725,7 +2671,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#C1E1C5"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1761,7 +2729,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#BEDADC"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1797,7 +2787,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#C4DEF6"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1833,7 +2845,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#BED3F3"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1869,7 +2903,29 @@ exports[`Github renders correctly 1`] = `
           }
           tabIndex={0}
           title="#D4C4FB"
-        />
+        >
+          <div
+            style={
+              Object {
+                "display": "none",
+                "fill": "#000",
+              }
+            }
+          >
+            <svg
+              style={
+                Object {
+                  "margin": "3px",
+                }
+              }
+              viewBox="0 0 25 25"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </div>
+        </div>
       </span>
     </div>
   </span>
@@ -1909,7 +2965,29 @@ exports[`GithubSwatch renders correctly 1`] = `
         }
         tabIndex={0}
         title="#333"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "3px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
   </div>
 </span>

--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -6,115 +6,129 @@ import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Swatch } from '../common'
 
-export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
-  className = '' }) => {
-  const styles = reactCSS({
-    'default': {
-      card: {
-        width,
-        background: '#fff',
-        border: '0 solid rgba(0,0,0,0.25)',
-        boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
-        borderRadius: '4px',
-        position: 'relative',
-      },
-      body: {
-        padding: '15px 9px 9px 15px',
-      },
-      label: {
-        fontSize: '18px',
-        color: '#fff',
-      },
-      triangle: {
-        width: '0px',
-        height: '0px',
-        borderStyle: 'solid',
-        borderWidth: '0 9px 10px 9px',
-        borderColor: 'transparent transparent #fff transparent',
-        position: 'absolute',
-      },
-      triangleShadow: {
-        width: '0px',
-        height: '0px',
-        borderStyle: 'solid',
-        borderWidth: '0 9px 10px 9px',
-        borderColor: 'transparent transparent rgba(0,0,0,.1) transparent',
-        position: 'absolute',
-      },
-      hash: {
-        background: '#F0F0F0',
-        height: '30px',
-        width: '30px',
-        borderRadius: '4px 0 0 4px',
-        float: 'left',
-        color: '#98A1A4',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      },
-      input: {
-        width: '100px',
-        fontSize: '14px',
-        color: '#666',
-        border: '0px',
-        outline: 'none',
-        height: '28px',
-        boxShadow: 'inset 0 0 0 1px #F0F0F0',
-        boxSizing: 'content-box',
-        borderRadius: '0 4px 4px 0',
-        float: 'left',
-        paddingLeft: '8px',
-      },
-      swatch: {
-        width: '30px',
-        height: '30px',
-        float: 'left',
-        borderRadius: '4px',
-        margin: '0 6px 6px 0',
-      },
-      clear: {
-        clear: 'both',
-      },
-    },
-    'hide-triangle': {
-      triangle: {
-        display: 'none',
-      },
-      triangleShadow: {
-        display: 'none',
-      },
-    },
-    'top-left-triangle': {
-      triangle: {
-        top: '-10px',
-        left: '12px',
-      },
-      triangleShadow: {
-        top: '-11px',
-        left: '12px',
-      },
-    },
-    'top-right-triangle': {
-      triangle: {
-        top: '-10px',
-        right: '12px',
-      },
-      triangleShadow: {
-        top: '-11px',
-        right: '12px',
-      },
-    },
-  }, {
-    'hide-triangle': triangle === 'hide',
-    'top-left-triangle': triangle === 'top-left',
-    'top-right-triangle': triangle === 'top-right',
-  })
+export const Twitter = ({
+  onChange,
+  onSwatchHover,
+  hex,
+  colors,
+  width,
+  triangle,
+  className = '',
+}) => {
 
+  const styles = reactCSS(
+    {
+      default: {
+        card: {
+          width,
+          background: '#fff',
+          border: '0 solid rgba(0,0,0,0.25)',
+          boxShadow: '0 1px 4px rgba(0,0,0,0.25)',
+          borderRadius: '4px',
+          position: 'relative',
+        },
+        body: {
+          padding: '15px 9px 9px 15px',
+        },
+        label: {
+          fontSize: '18px',
+          color: '#fff',
+        },
+        triangle: {
+          width: '0px',
+          height: '0px',
+          borderStyle: 'solid',
+          borderWidth: '0 9px 10px 9px',
+          borderColor: 'transparent transparent #fff transparent',
+          position: 'absolute',
+        },
+        triangleShadow: {
+          width: '0px',
+          height: '0px',
+          borderStyle: 'solid',
+          borderWidth: '0 9px 10px 9px',
+          borderColor: 'transparent transparent rgba(0,0,0,.1) transparent',
+          position: 'absolute',
+        },
+        hash: {
+          background: '#F0F0F0',
+          height: '30px',
+          width: '30px',
+          borderRadius: '4px 0 0 4px',
+          float: 'left',
+          color: '#98A1A4',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        },
+        input: {
+          width: '100px',
+          fontSize: '14px',
+          color: '#666',
+          border: '0px',
+          outline: 'none',
+          height: '28px',
+          boxShadow: 'inset 0 0 0 1px #F0F0F0',
+          boxSizing: 'content-box',
+          borderRadius: '0 4px 4px 0',
+          float: 'left',
+          paddingLeft: '8px',
+        },
+        swatch: {
+          width: '30px',
+          height: '30px',
+          float: 'left',
+          borderRadius: '4px',
+          margin: '0 6px 6px 0',
+        },
+        clear: {
+          clear: 'both',
+        },
+      },
+      'hide-triangle': {
+        triangle: {
+          display: 'none',
+        },
+        triangleShadow: {
+          display: 'none',
+        },
+      },
+      'top-left-triangle': {
+        triangle: {
+          top: '-10px',
+          left: '12px',
+        },
+        triangleShadow: {
+          top: '-11px',
+          left: '12px',
+        },
+      },
+      'top-right-triangle': {
+        triangle: {
+          top: '-10px',
+          right: '12px',
+        },
+        triangleShadow: {
+          top: '-11px',
+          right: '12px',
+        },
+      },
+    },
+    {
+      'hide-triangle': triangle === 'hide',
+      'top-left-triangle': triangle === 'top-left',
+      'top-right-triangle': triangle === 'top-right',
+    }
+  )
   const handleChange = (hexcode, e) => {
-    color.isValidHex(hexcode) && onChange({
-      hex: hexcode,
-      source: 'hex',
-    }, e)
+    color.isValidHex(hexcode) &&
+      onChange(
+        {
+          hex: hexcode,
+          source: 'hex',
+        },
+        e
+      )
   }
 
   return (
@@ -123,10 +137,41 @@ export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
       <div style={ styles.triangle } />
 
       <div style={ styles.body }>
-        { map(colors, (c, i) => {
+        {map(colors, (c) => {
+          const activeStyles = reactCSS(
+            {
+              default: {
+                check: {
+                  fill: color.getContrastingColor(c),
+                  display: 'none',
+                },
+              },
+              active: {
+                check: {
+                  display: 'block',
+                },
+              },
+              'color-#FFFFFF': {
+                check: {
+                  fill: '#333',
+                },
+              },
+              transparent: {
+                check: {
+                  fill: '#333',
+                },
+              },
+            },
+            {
+              'color-#FFFFFF': c === '#FFFFFF',
+              transparent: c === 'transparent',
+              active: c && (hex === c.toLowerCase()),
+            }
+          )
+          console.log(hex , c && c.toLowerCase(), hex === c && c.toLowerCase())
           return (
             <Swatch
-              key={ i }
+              key={ c }
               color={ c }
               hex={ c }
               style={ styles.swatch }
@@ -135,9 +180,15 @@ export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
               focusStyle={{
                 boxShadow: `0 0 4px ${ c }`,
               }}
-            />
+            >
+              <div style={ activeStyles.check }>
+                <svg style={{ margin: '4px' }} viewBox="0 0 25 25">
+                  <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+                </svg>
+              </div>
+            </Swatch>
           )
-        }) }
+        })}
         <div style={ styles.hash }>#</div>
         <EditableInput
           style={{ input: styles.input }}
@@ -158,8 +209,18 @@ Twitter.propTypes = {
 
 Twitter.defaultProps = {
   width: 276,
-  colors: ['#FF6900', '#FCB900', '#7BDCB5', '#00D084', '#8ED1FC', '#0693E3',
-    '#ABB8C3', '#EB144C', '#F78DA7', '#9900EF'],
+  colors: [
+    '#FF6900',
+    '#FCB900',
+    '#7BDCB5',
+    '#00D084',
+    '#8ED1FC',
+    '#0693E3',
+    '#ABB8C3',
+    '#EB144C',
+    '#F78DA7',
+    '#9900EF',
+  ],
   triangle: 'top-left',
 }
 

--- a/src/components/twitter/__snapshots__/spec.js.snap
+++ b/src/components/twitter/__snapshots__/spec.js.snap
@@ -81,7 +81,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#FF6900"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -109,7 +131,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#FCB900"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -137,7 +181,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#7BDCB5"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -165,7 +231,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#00D084"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -193,7 +281,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#8ED1FC"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -221,7 +331,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#0693E3"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -249,7 +381,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#ABB8C3"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -277,7 +431,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#EB144C"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -305,7 +481,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#F78DA7"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -333,7 +531,29 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
         }
         tabIndex={0}
         title="#9900EF"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <div
       style={
@@ -490,7 +710,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#FF6900"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -518,7 +760,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#FCB900"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -546,7 +810,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#7BDCB5"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -574,7 +860,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#00D084"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -602,7 +910,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#8ED1FC"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -630,7 +960,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#0693E3"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -658,7 +1010,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#ABB8C3"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -686,7 +1060,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#EB144C"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -714,7 +1110,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#F78DA7"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -742,7 +1160,29 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
         }
         tabIndex={0}
         title="#9900EF"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <div
       style={
@@ -899,7 +1339,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#FF6900"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -927,7 +1389,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#FCB900"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -955,7 +1439,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#7BDCB5"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -983,7 +1489,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#00D084"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -1011,7 +1539,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#8ED1FC"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -1039,7 +1589,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#0693E3"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -1067,7 +1639,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#ABB8C3"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -1095,7 +1689,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#EB144C"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -1123,7 +1739,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#F78DA7"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#000",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <span
       onBlur={[Function]}
@@ -1151,7 +1789,29 @@ exports[`Twitter renders correctly 1`] = `
         }
         tabIndex={0}
         title="#9900EF"
-      />
+      >
+        <div
+          style={
+            Object {
+              "display": "none",
+              "fill": "#fff",
+            }
+          }
+        >
+          <svg
+            style={
+              Object {
+                "margin": "4px",
+              }
+            }
+            viewBox="0 0 25 25"
+          >
+            <path
+              d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+            />
+          </svg>
+        </div>
+      </div>
     </span>
     <div
       style={


### PR DESCRIPTION
All Pickers except Github & Tiwtter support setting a selected color through `color` prop, which is very importing to indicate to the end user the current selected color, specially with a huge list of colors.

this PR is about adding support of selected color to GithubPicker & TwitterPicker by passing color prop.

```javascript
<TwitterPicker
        color="#fff"
/>

<GithubPicker
        color="#fff"
/>
```


- [x] eslint
- [x] all tests passed (updated 7 snapshots related to github & twitter tests)  

