### PR TITLE
React 16.2.x runtime throws an exception on ES7 autobind render()

### DIFF
--- a/src/helpers/interaction.js
+++ b/src/helpers/interaction.js
@@ -7,9 +7,11 @@ export const handleFocus = (Component, Span = 'span') =>
     handleFocus = () => this.setState({ focus: true })
     handleBlur = () => this.setState({ focus: false })
 
-    render = () => (
-      <Span onFocus={ this.handleFocus } onBlur={ this.handleBlur }>
-        <Component { ...this.props } { ...this.state } />
-      </Span>
-    )
+    render() {
+      return (
+        <Span onFocus={ this.handleFocus } onBlur={ this.handleBlur }>
+          <Component { ...this.props } { ...this.state } />
+        </Span>
+      )
+    }
   }


### PR DESCRIPTION
Any usage of this component with the latest React causes:

```
Cannot assign to read only property 'render' of object '#<ProxyComponent>'
```

This PR changes `render = () =>` syntax to regular method declaration in handleFocus component.
