### PR TITLE
fix circular dependency between common/Swatch.js and common/index.js

### DIFF
--- a/src/components/common/Swatch.js
+++ b/src/components/common/Swatch.js
@@ -2,7 +2,7 @@ import React from 'react'
 import reactCSS from 'reactcss'
 import { handleFocus } from '../../helpers/interaction'
 
-import { Checkboard } from './'
+import Checkboard from './Checkboard'
 
 const ENTER = 13
 


### PR DESCRIPTION
there is a circular dependency between components/common/Swatch.js and components/common/index.js. Index imports Swatch in order to export it, but Swatch is also importing Checkboard from index instead of just directly importing it from Checkboard.js.

My build setup was complaining about the circular dependency when directly doing `import SketchPicker from 'react-color/lib/Sketch';` to get just the sketch picker. Doing `import { SketchPicker } from 'react-color';` gave no warning, but also pulls all the other stuff into my build that isn't needed.