### PR TITLE
Fix hover effect of ChromeField's toggle button

### DIFF
--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -78,11 +78,11 @@ export class ChromeFields extends React.Component {
   }
 
   showHighlight = (e) => {
-    e.target.style.background = '#eee'
+    e.currentTarget.style.background = '#eee'
   }
 
   hideHighlight = (e) => {
-    e.target.style.background = 'transparent'
+    e.currentTarget.style.background = 'transparent'
   }
 
   render() {


### PR DESCRIPTION
The button's background should change when hovering over the parent element or its children.

Before:
![bildschirmfoto von 2018-08-03 11 26 41](https://user-images.githubusercontent.com/3716206/43624692-3e173e32-9713-11e8-8fcc-5a53d3589d42.jpg)

After:
![bildschirmfoto von 2018-08-03 11 47 07](https://user-images.githubusercontent.com/3716206/43624708-525bbed6-9713-11e8-9a85-ab737500ab5d.jpg)
