### PR TITLE
Fix memory leak on Saturation when unmount and throttle

### DIFF
--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -13,6 +13,7 @@ export class Saturation extends (PureComponent || Component) {
   }
 
   componentWillUnmount() {
+    this.throttle.cancel()
     this.unbindEventListeners()
   }
 


### PR DESCRIPTION
Having a problem right now that throttle sometimes trigger after the unmount. That will result in a memory leak by doing `setState` on unmounted components. Also getting weird behavior after that memory leak triggers.