### PR TITLE
Added "role" aria attribute 

### DIFF
--- a/src/components/common/Swatch.js
+++ b/src/components/common/Swatch.js
@@ -39,6 +39,7 @@ export const Swatch = ({ color, style, onClick = () => {}, onHover, title = colo
       onClick={ handleClick }
       title={ title }
       tabIndex={ 0 }
+      role={ "button" }
       onKeyDown={ handleKeyDown }
       { ...optionalEvents }
     >


### PR DESCRIPTION
Adding the `role="button"` attribute to a clickable elements makes it easier for screen-readers to understand it is a button

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/button_role