### PR TITLE
Replaced default style of slider component to null

### DIFF
--- a/src/components/slider/Slider.js
+++ b/src/components/slider/Slider.js
@@ -22,7 +22,7 @@ export const Slider = ({ hsl, onChange, pointer,
   }, passedStyles))
 
   return (
-    <div style={ styles.wrap || null } className={ `slider-picker ${ className }` }>
+    <div style={ styles.wrap || {} } className={ `slider-picker ${ className }` }>
       <div style={ styles.hue }>
         <Hue
           style={ styles.Hue }

--- a/src/components/slider/Slider.js
+++ b/src/components/slider/Slider.js
@@ -22,7 +22,7 @@ export const Slider = ({ hsl, onChange, pointer,
   }, passedStyles))
 
   return (
-    <div style={ styles.wrap || '' } className={ `slider-picker ${ className }` }>
+    <div style={ styles.wrap || null } className={ `slider-picker ${ className }` }>
       <div style={ styles.hue }>
         <Hue
           style={ styles.Hue }

--- a/src/components/slider/__snapshots__/spec.js.snap
+++ b/src/components/slider/__snapshots__/spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Slider renders correctly 1`] = `
 <div
   className="slider-picker "
-  style=""
+  style={null}
 >
   <div
     style={

--- a/src/components/slider/__snapshots__/spec.js.snap
+++ b/src/components/slider/__snapshots__/spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Slider renders correctly 1`] = `
 <div
   className="slider-picker "
-  style={null}
+  style={Object {}}
 >
   <div
     style={


### PR DESCRIPTION
resolves issue #565

Replaced the default style of slider component to null instead of empty string b/c style does not accept an empty string as a valid value. Currently using the component's default styles will cause the component to break, this fixes the bug.