### PR TITLE
Refactor helper methods alpha, hue and saturation

### DIFF
--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -9,13 +9,13 @@ export class Alpha extends (PureComponent || Component) {
     this.unbindEventListeners()
   }
 
-  handleChange = (e, skip) => {
-    const change = alpha.calculateChange(e, skip, this.props, this.container)
-    change && this.props.onChange && this.props.onChange(change, e)
+  handleChange = (e) => {
+    const change = alpha.calculateChange(e, this.props.hsl, this.props.direction, this.props.a, this.container)
+    change && typeof this.props.onChange === 'function' && this.props.onChange(change, e)
   }
 
   handleMouseDown = (e) => {
-    this.handleChange(e, true)
+    this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)
   }

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -7,13 +7,13 @@ export class Hue extends (PureComponent || Component) {
     this.unbindEventListeners()
   }
 
-  handleChange = (e, skip) => {
-    const change = hue.calculateChange(e, skip, this.props, this.container)
-    change && this.props.onChange && this.props.onChange(change, e)
+  handleChange = (e) => {
+    const change = hue.calculateChange(e, this.props.direction, this.props.hsl, this.container)
+    change && typeof this.props.onChange === 'function' && this.props.onChange(change, e)
   }
 
   handleMouseDown = (e) => {
-    this.handleChange(e, true)
+    this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)
   }

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -17,16 +17,16 @@ export class Saturation extends (PureComponent || Component) {
     this.unbindEventListeners()
   }
 
-  handleChange = (e, skip) => {
-    this.props.onChange && this.throttle(
+  handleChange = (e) => {
+    typeof this.props.onChange === 'function' && this.throttle(
       this.props.onChange,
-      saturation.calculateChange(e, skip, this.props, this.container),
+      saturation.calculateChange(e, this.props.hsl, this.container),
       e,
     )
   }
 
   handleMouseDown = (e) => {
-    this.handleChange(e, true)
+    this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)
   }

--- a/src/helpers/alpha.js
+++ b/src/helpers/alpha.js
@@ -1,4 +1,4 @@
-export const calculateChange = (e, skip, props, container) => {
+export const calculateChange = (e, hsl, direction, initialA, container) => {
   e.preventDefault()
   const containerWidth = container.clientWidth
   const containerHeight = container.clientHeight
@@ -7,7 +7,7 @@ export const calculateChange = (e, skip, props, container) => {
   const left = x - (container.getBoundingClientRect().left + window.pageXOffset)
   const top = y - (container.getBoundingClientRect().top + window.pageYOffset)
 
-  if (props.direction === 'vertical') {
+  if (direction === 'vertical') {
     let a
     if (top < 0) {
       a = 0
@@ -17,11 +17,11 @@ export const calculateChange = (e, skip, props, container) => {
       a = Math.round((top * 100) / containerHeight) / 100
     }
 
-    if (props.hsl.a !== a) {
+    if (hsl.a !== a) {
       return {
-        h: props.hsl.h,
-        s: props.hsl.s,
-        l: props.hsl.l,
+        h: hsl.h,
+        s: hsl.s,
+        l: hsl.l,
         a,
         source: 'rgb',
       }
@@ -36,11 +36,11 @@ export const calculateChange = (e, skip, props, container) => {
       a = Math.round((left * 100) / containerWidth) / 100
     }
 
-    if (props.a !== a) {
+    if (initialA !== a) {
       return {
-        h: props.hsl.h,
-        s: props.hsl.s,
-        l: props.hsl.l,
+        h: hsl.h,
+        s: hsl.s,
+        l: hsl.l,
         a,
         source: 'rgb',
       }

--- a/src/helpers/hue.js
+++ b/src/helpers/hue.js
@@ -1,4 +1,4 @@
-export const calculateChange = (e, skip, props, container) => {
+export const calculateChange = (e, direction, hsl, container) => {
   e.preventDefault()
   const containerWidth = container.clientWidth
   const containerHeight = container.clientHeight
@@ -7,7 +7,7 @@ export const calculateChange = (e, skip, props, container) => {
   const left = x - (container.getBoundingClientRect().left + window.pageXOffset)
   const top = y - (container.getBoundingClientRect().top + window.pageYOffset)
 
-  if (props.direction === 'vertical') {
+  if (direction === 'vertical') {
     let h
     if (top < 0) {
       h = 359
@@ -18,12 +18,12 @@ export const calculateChange = (e, skip, props, container) => {
       h = ((360 * percent) / 100)
     }
 
-    if (props.hsl.h !== h) {
+    if (hsl.h !== h) {
       return {
         h,
-        s: props.hsl.s,
-        l: props.hsl.l,
-        a: props.hsl.a,
+        s: hsl.s,
+        l: hsl.l,
+        a: hsl.a,
         source: 'rgb',
       }
     }
@@ -38,12 +38,12 @@ export const calculateChange = (e, skip, props, container) => {
       h = ((360 * percent) / 100)
     }
 
-    if (props.hsl.h !== h) {
+    if (hsl.h !== h) {
       return {
         h,
-        s: props.hsl.s,
-        l: props.hsl.l,
-        a: props.hsl.a,
+        s: hsl.s,
+        l: hsl.l,
+        a: hsl.a,
         source: 'rgb',
       }
     }

--- a/src/helpers/saturation.js
+++ b/src/helpers/saturation.js
@@ -1,4 +1,4 @@
-export const calculateChange = (e, skip, props, container) => {
+export const calculateChange = (e, hsl, container) => {
   e.preventDefault()
   const { width: containerWidth, height: containerHeight } = container.getBoundingClientRect()
   const x = typeof e.pageX === 'number' ? e.pageX : e.touches[0].pageX
@@ -20,10 +20,10 @@ export const calculateChange = (e, skip, props, container) => {
   const bright = -((top * 100) / containerHeight) + 100
 
   return {
-    h: props.hsl.h,
+    h: hsl.h,
     s: saturation,
     v: bright,
-    a: props.hsl.a,
+    a: hsl.a,
     source: 'rgb',
   }
 }


### PR DESCRIPTION
The following applies to all three helper methods for alpha, hue and saturation:
1. We exposed an unused argument `skip` in our public methods `calculateChange()`. I removed this guy from the function signatures, and updated all consumers to reflect this new API
2. We should not couple our component logic to our helper methods by passing the entire `this.props` to our public methods. For example. if we wanted to rename the props inside our `Alpha` component, we'd have to make a corresponding change to our helper function in `alpha.js` as well. I updated the helper function to take explicit arguments instead of `props`, and also updated the consumers to reflect this API.
3. I made our check for the `onChange` prop a bit more defensive by checking if `onChange` is a function, rather than just checking if its truthy. This will stop errors that occur when consumers pass anything other than a function for the `onChange` prop.