### PR TITLE
Support 'width' as a prop for ChromePicker

### DIFF
--- a/src/components/chrome/Chrome.js
+++ b/src/components/chrome/Chrome.js
@@ -8,16 +8,16 @@ import ChromeFields from './ChromeFields'
 import ChromePointer from './ChromePointer'
 import ChromePointerCircle from './ChromePointerCircle'
 
-export const Chrome = ({ onChange, disableAlpha, rgb, hsl, hsv, hex, renderers,
+export const Chrome = ({ width, onChange, disableAlpha, rgb, hsl, hsv, hex, renderers,
   styles: passedStyles = {}, className = '' }) => {
   const styles = reactCSS(merge({
     'default': {
       picker: {
+        width,
         background: '#fff',
         borderRadius: '2px',
         boxShadow: '0 0 2px rgba(0,0,0,.3), 0 4px 8px rgba(0,0,0,.3)',
         boxSizing: 'initial',
-        width: '225px',
         fontFamily: 'Menlo',
       },
       saturation: {
@@ -144,11 +144,13 @@ export const Chrome = ({ onChange, disableAlpha, rgb, hsl, hsv, hex, renderers,
 }
 
 Chrome.propTypes = {
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disableAlpha: PropTypes.bool,
   styles: PropTypes.object,
 }
 
 Chrome.defaultProps = {
+  width: 225,
   disableAlpha: false,
   styles: {},
 }

--- a/src/components/chrome/__snapshots__/spec.js.snap
+++ b/src/components/chrome/__snapshots__/spec.js.snap
@@ -18,7 +18,7 @@ exports[`Chrome renders correctly 1`] = `
       "fontFamily": "Menlo",
       "msBorderRadius": "2px",
       "msBoxShadow": "0 0 2px rgba(0,0,0,.3), 0 4px 8px rgba(0,0,0,.3)",
-      "width": "225px",
+      "width": 225,
     }
   }
 >

--- a/src/components/chrome/spec.js
+++ b/src/components/chrome/spec.js
@@ -75,3 +75,10 @@ test('Chrome renders custom styles correctly', () => {
   ).toJSON()
   expect(tree.props.style.boxShadow).toBe('none')
 })
+
+test('Chrome renders correctly with width', () => {
+  const tree = renderer.create(
+    <Chrome width={300} />,
+  ).toJSON()
+  expect(tree.props.style.width).toBe(300)
+});


### PR DESCRIPTION
In regards to #578, this PR will support `width` as a prop for ChromePicker.

*  225px (default)
![image](https://user-images.githubusercontent.com/7133704/51796867-ec68a400-21c7-11e9-9f3a-5a200596af3a.png)
* 450px
![image](https://user-images.githubusercontent.com/7133704/51796927-e32c0700-21c8-11e9-9e87-b7b595c1d57f.png)