### PR TITLE
chore: update lodash to 4.7.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "dependencies": {
     "@icons/material": "^0.2.4",
-    "lodash": ">4.17.4",
+    "lodash": "^4.17.11",
     "material-colors": "^1.2.1",
     "prop-types": "^15.5.10",
     "reactcss": "^1.2.0",


### PR DESCRIPTION
I updated lodash to 4.7.11.
It fixed CVE-2018-16487.

> A prototype pollution vulnerability was found in lodash <4.17.11 where the functions merge, mergeWith, and defaultsDeep can be tricked into adding or modifying properties of Object.prototype.

See https://nvd.nist.gov/vuln/detail/CVE-2018-16487
