### PR TITLE
Fix touch event issue

### DIFF
--- a/src/components/alpha/__snapshots__/spec.js.snap
+++ b/src/components/alpha/__snapshots__/spec.js.snap
@@ -92,8 +92,6 @@ exports[`Alpha renders correctly 1`] = `
     />
     <div
       onMouseDown={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
       style={
         Object {
           "height": "100%",
@@ -232,8 +230,6 @@ exports[`Alpha renders vertically 1`] = `
     />
     <div
       onMouseDown={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
       style={
         Object {
           "height": "100%",

--- a/src/components/alpha/spec.js
+++ b/src/components/alpha/spec.js
@@ -4,6 +4,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme'
 import color, { red } from '../../helpers/color'
+import { createNodeMock } from '../../../support/createNodeMock'
 // import canvas from 'canvas'
 
 import Alpha from './Alpha'
@@ -13,6 +14,7 @@ import AlphaPointer from './AlphaPointer'
 test('Alpha renders correctly', () => {
   const tree = renderer.create(
     <Alpha { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -43,6 +45,7 @@ test('Alpha onChange events correctly', () => {
 test('Alpha renders vertically', () => {
   const tree = renderer.create(
     <Alpha { ...red } width={ 20 } height={ 200 } direction="vertical" />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/chrome/__snapshots__/spec.js.snap
+++ b/src/components/chrome/__snapshots__/spec.js.snap
@@ -39,8 +39,6 @@ exports[`Chrome renders correctly 1`] = `
   >
     <div
       onMouseDown={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
       style={
         Object {
           "MozBorderRadius": undefined,
@@ -274,8 +272,6 @@ exports[`Chrome renders correctly 1`] = `
             <div
               className="hue-horizontal"
               onMouseDown={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
               style={
                 Object {
                   "MozBorderRadius": undefined,
@@ -431,8 +427,6 @@ exports[`Chrome renders correctly 1`] = `
             />
             <div
               onMouseDown={[Function]}
-              onTouchMove={[Function]}
-              onTouchStart={[Function]}
               style={
                 Object {
                   "height": "100%",

--- a/src/components/chrome/spec.js
+++ b/src/components/chrome/spec.js
@@ -4,6 +4,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import color, { red } from '../../helpers/color'
 import { mount } from 'enzyme'
+import { createNodeMock } from '../../../support/createNodeMock'
 
 import Chrome from './Chrome'
 import ChromeFields from './ChromeFields'
@@ -11,10 +12,10 @@ import ChromePointer from './ChromePointer'
 import ChromePointerCircle from './ChromePointerCircle'
 import { Alpha } from '../common'
 
-
 test('Chrome renders correctly', () => {
   const tree = renderer.create(
     <Chrome { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -72,6 +73,7 @@ test('ChromePointerCircle renders correctly', () => {
 test('Chrome renders custom styles correctly', () => {
   const tree = renderer.create(
     <Chrome styles={{ default: { picker: { boxShadow: 'none' } } }} />,
+    { createNodeMock },
   ).toJSON()
   expect(tree.props.style.boxShadow).toBe('none')
 })
@@ -79,6 +81,7 @@ test('Chrome renders custom styles correctly', () => {
 test('Chrome renders correctly with width', () => {
   const tree = renderer.create(
     <Chrome width={300} />,
+    { createNodeMock },
   ).toJSON()
   expect(tree.props.style.width).toBe(300)
 });

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -11,16 +11,18 @@ export class Alpha extends (PureComponent || Component) {
     this.container = null
   }
   
-  componentWillUnmount() {
-    this.unbindEventListeners()
-  }
-
   componentDidMount() {
     // e.preventDefault() does not work properly on React synthetic touch event.
     // As a workaround, touch events have to be added to directly to node
     // https://github.com/facebook/react/issues/9809#issuecomment-414072263
     this.container.addEventListener('touchstart', this.handleChange)
     this.container.addEventListener('touchmove', this.handleChange)
+  }
+
+  componentWillUnmount() {
+    this.unbindEventListeners()
+    this.container.removeEventListener('touchstart', this.handleChange)
+    this.container.removeEventListener('touchmove', this.handleChange)
   }
 
   handleChange = (e) => {

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -16,6 +16,9 @@ export class Alpha extends (PureComponent || Component) {
   }
 
   componentDidMount() {
+    // e.preventDefault() does not work properly on React synthetic touch event.
+    // As a workaround, touch events have to be added to directly to node
+    // https://github.com/facebook/react/issues/9809#issuecomment-414072263
     this.container.addEventListener('touchstart', this.handleChange)
     this.container.addEventListener('touchmove', this.handleChange)
   }

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -19,7 +19,10 @@ export class Alpha extends (PureComponent || Component) {
     // e.preventDefault() does not work properly on React synthetic touch event.
     // As a workaround, touch events have to be added to directly to node
     // https://github.com/facebook/react/issues/9809#issuecomment-414072263
-    this.container.addEventListener('touchstart', this.handleChange)
+    this.container.addEventListener('touchstart', (e) => {
+      document.activeElement.blur()
+      this.handleChange(e)
+    })
     this.container.addEventListener('touchmove', this.handleChange)
   }
 
@@ -29,6 +32,7 @@ export class Alpha extends (PureComponent || Component) {
   }
 
   handleMouseDown = (e) => {
+    document.activeElement.blur()
     this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -19,10 +19,7 @@ export class Alpha extends (PureComponent || Component) {
     // e.preventDefault() does not work properly on React synthetic touch event.
     // As a workaround, touch events have to be added to directly to node
     // https://github.com/facebook/react/issues/9809#issuecomment-414072263
-    this.container.addEventListener('touchstart', (e) => {
-      document.activeElement.blur()
-      this.handleChange(e)
-    })
+    this.container.addEventListener('touchstart', this.handleChange)
     this.container.addEventListener('touchmove', this.handleChange)
   }
 
@@ -32,7 +29,6 @@ export class Alpha extends (PureComponent || Component) {
   }
 
   handleMouseDown = (e) => {
-    document.activeElement.blur()
     this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)

--- a/src/components/common/Alpha.js
+++ b/src/components/common/Alpha.js
@@ -5,8 +5,19 @@ import * as alpha from '../../helpers/alpha'
 import Checkboard from './Checkboard'
 
 export class Alpha extends (PureComponent || Component) {
+  constructor(props) {
+    super(props)
+
+    this.container = null
+  }
+  
   componentWillUnmount() {
     this.unbindEventListeners()
+  }
+
+  componentDidMount() {
+    this.container.addEventListener('touchstart', this.handleChange)
+    this.container.addEventListener('touchmove', this.handleChange)
   }
 
   handleChange = (e) => {
@@ -96,8 +107,6 @@ export class Alpha extends (PureComponent || Component) {
           style={ styles.container }
           ref={ container => this.container = container }
           onMouseDown={ this.handleMouseDown }
-          onTouchMove={ this.handleChange }
-          onTouchStart={ this.handleChange }
         >
           <div style={ styles.pointer }>
             { this.props.pointer ? (

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -10,6 +10,9 @@ export class Hue extends (PureComponent || Component) {
   }
   
   componentDidMount() {
+    // e.preventDefault() does not work properly on React synthetic touch event.
+    // As a workaround, touch events have to be added to directly to node
+    // https://github.com/facebook/react/issues/9809#issuecomment-414072263
     this.container.addEventListener('touchstart', this.handleChange)
     this.container.addEventListener('touchmove', this.handleChange)
   }

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -13,10 +13,7 @@ export class Hue extends (PureComponent || Component) {
     // e.preventDefault() does not work properly on React synthetic touch event.
     // As a workaround, touch events have to be added to directly to node
     // https://github.com/facebook/react/issues/9809#issuecomment-414072263
-    this.container.addEventListener('touchstart', (e) => {
-      document.activeElement.blur()
-      this.handleChange(e)
-    })
+    this.container.addEventListener('touchstart', this.handleChange)
     this.container.addEventListener('touchmove', this.handleChange)
   }
   
@@ -30,7 +27,6 @@ export class Hue extends (PureComponent || Component) {
   }
 
   handleMouseDown = (e) => {
-    document.activeElement.blur()
     this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -13,7 +13,10 @@ export class Hue extends (PureComponent || Component) {
     // e.preventDefault() does not work properly on React synthetic touch event.
     // As a workaround, touch events have to be added to directly to node
     // https://github.com/facebook/react/issues/9809#issuecomment-414072263
-    this.container.addEventListener('touchstart', this.handleChange)
+    this.container.addEventListener('touchstart', (e) => {
+      document.activeElement.blur()
+      this.handleChange(e)
+    })
     this.container.addEventListener('touchmove', this.handleChange)
   }
   
@@ -27,6 +30,7 @@ export class Hue extends (PureComponent || Component) {
   }
 
   handleMouseDown = (e) => {
+    document.activeElement.blur()
     this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -3,6 +3,17 @@ import reactCSS from 'reactcss'
 import * as hue from '../../helpers/hue'
 
 export class Hue extends (PureComponent || Component) {
+  constructor(props) {
+    super(props)
+
+    this.container = null
+  }
+  
+  componentDidMount() {
+    this.container.addEventListener('touchstart', this.handleChange)
+    this.container.addEventListener('touchmove', this.handleChange)
+  }
+  
   componentWillUnmount() {
     this.unbindEventListeners()
   }
@@ -72,8 +83,6 @@ export class Hue extends (PureComponent || Component) {
           style={ styles.container }
           ref={ container => this.container = container }
           onMouseDown={ this.handleMouseDown }
-          onTouchMove={ this.handleChange }
-          onTouchStart={ this.handleChange }
         >
           <style>{ `
             .hue-horizontal {

--- a/src/components/common/Hue.js
+++ b/src/components/common/Hue.js
@@ -19,6 +19,8 @@ export class Hue extends (PureComponent || Component) {
   
   componentWillUnmount() {
     this.unbindEventListeners()
+    this.container.removeEventListener('touchstart', this.handleChange)
+    this.container.removeEventListener('touchmove', this.handleChange)
   }
 
   handleChange = (e) => {

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -18,10 +18,7 @@ export class Saturation extends (PureComponent || Component) {
     // e.preventDefault() does not work properly on React synthetic touch event.
     // As a workaround, touch events have to be added to directly to node
     // https://github.com/facebook/react/issues/9809#issuecomment-414072263
-    this.container.addEventListener('touchstart', (e) => {
-      document.activeElement.blur()
-      this.handleChange(e)
-    })
+    this.container.addEventListener('touchstart', this.handleChange)
     this.container.addEventListener('touchmove', this.handleChange)
   }
 
@@ -39,8 +36,7 @@ export class Saturation extends (PureComponent || Component) {
   }
 
   handleMouseDown = (e) => {
-    document.activeElement.blur()
-    this.handleChange(e)    
+    this.handleChange(e)
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)
   }

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -25,6 +25,8 @@ export class Saturation extends (PureComponent || Component) {
   componentWillUnmount() {
     this.throttle.cancel()
     this.unbindEventListeners()
+    this.container.removeEventListener('touchstart', this.handleChange)
+    this.container.removeEventListener('touchmove', this.handleChange)
   }
 
   handleChange = (e) => {

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -18,7 +18,10 @@ export class Saturation extends (PureComponent || Component) {
     // e.preventDefault() does not work properly on React synthetic touch event.
     // As a workaround, touch events have to be added to directly to node
     // https://github.com/facebook/react/issues/9809#issuecomment-414072263
-    this.container.addEventListener('touchstart', this.handleChange)
+    this.container.addEventListener('touchstart', (e) => {
+      document.activeElement.blur()
+      this.handleChange(e)
+    })
     this.container.addEventListener('touchmove', this.handleChange)
   }
 
@@ -36,7 +39,8 @@ export class Saturation extends (PureComponent || Component) {
   }
 
   handleMouseDown = (e) => {
-    this.handleChange(e)
+    document.activeElement.blur()
+    this.handleChange(e)    
     window.addEventListener('mousemove', this.handleChange)
     window.addEventListener('mouseup', this.handleMouseUp)
   }

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -15,6 +15,9 @@ export class Saturation extends (PureComponent || Component) {
   }
 
   componentDidMount() {
+    // e.preventDefault() does not work properly on React synthetic touch event.
+    // As a workaround, touch events have to be added to directly to node
+    // https://github.com/facebook/react/issues/9809#issuecomment-414072263
     this.container.addEventListener('touchstart', this.handleChange)
     this.container.addEventListener('touchmove', this.handleChange)
   }

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -7,9 +7,16 @@ export class Saturation extends (PureComponent || Component) {
   constructor(props) {
     super(props)
 
+    this.container = null
+
     this.throttle = throttle((fn, data, e) => {
       fn(data, e)
     }, 50)
+  }
+
+  componentDidMount() {
+    this.container.addEventListener('touchstart', this.handleChange)
+    this.container.addEventListener('touchmove', this.handleChange)
   }
 
   componentWillUnmount() {
@@ -87,9 +94,7 @@ export class Saturation extends (PureComponent || Component) {
       <div
         style={ styles.color }
         ref={ container => this.container = container }
-        onMouseDown={ this.handleMouseDown }
-        onTouchMove={ this.handleChange }
-        onTouchStart={ this.handleChange }
+        onMouseDown={ this.handleMouseDown }        
       >
         <style>{`
           .saturation-white {

--- a/src/components/common/__snapshots__/spec.js.snap
+++ b/src/components/common/__snapshots__/spec.js.snap
@@ -82,8 +82,6 @@ exports[`Alpha renders correctly 1`] = `
   />
   <div
     onMouseDown={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
     style={
       Object {
         "height": "100%",
@@ -206,8 +204,6 @@ exports[`Hue renders correctly 1`] = `
   <div
     className="hue-horizontal"
     onMouseDown={[Function]}
-    onTouchMove={[Function]}
-    onTouchStart={[Function]}
     style={
       Object {
         "MozBorderRadius": undefined,
@@ -279,8 +275,6 @@ exports[`Hue renders correctly 1`] = `
 exports[`Saturation renders correctly 1`] = `
 <div
   onMouseDown={[Function]}
-  onTouchMove={[Function]}
-  onTouchStart={[Function]}
   style={
     Object {
       "MozBorderRadius": undefined,

--- a/src/components/common/spec.js
+++ b/src/components/common/spec.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { red } from '../../helpers/color'
+import { createNodeMock } from '../../../support/createNodeMock'
 // import canvas from 'canvas'
 
 import Alpha from './Alpha'
@@ -15,6 +16,7 @@ import Swatch from './Swatch'
 test('Alpha renders correctly', () => {
   const tree = renderer.create(
     <Alpha { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -50,6 +52,7 @@ test('EditableInput renders correctly', () => {
 test('Hue renders correctly', () => {
   const tree = renderer.create(
     <Hue { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -57,6 +60,7 @@ test('Hue renders correctly', () => {
 test('Saturation renders correctly', () => {
   const tree = renderer.create(
     <Saturation { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })

--- a/src/components/hue/__snapshots__/spec.js.snap
+++ b/src/components/hue/__snapshots__/spec.js.snap
@@ -35,8 +35,6 @@ exports[`Hue renders correctly 1`] = `
     <div
       className="hue-horizontal"
       onMouseDown={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
       style={
         Object {
           "MozBorderRadius": "2px",
@@ -140,8 +138,6 @@ exports[`Hue renders vertically 1`] = `
     <div
       className="hue-vertical"
       onMouseDown={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
       style={
         Object {
           "MozBorderRadius": "2px",

--- a/src/components/hue/spec.js
+++ b/src/components/hue/spec.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { red } from '../../helpers/color'
+import { createNodeMock } from '../../../support/createNodeMock'
 
 import Hue from './Hue'
 import HuePointer from './HuePointer'
@@ -10,6 +11,7 @@ import HuePointer from './HuePointer'
 test('Hue renders correctly', () => {
   const tree = renderer.create(
     <Hue { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -17,6 +19,7 @@ test('Hue renders correctly', () => {
 test('Hue renders vertically', () => {
   const tree = renderer.create(
     <Hue { ...red } width={ 20 } height={ 200 } direction="vertical" />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -24,6 +27,7 @@ test('Hue renders vertically', () => {
 test('Hue renders custom styles correctly', () => {
   const tree = renderer.create(
     <Hue { ...red } styles={{ default: { picker: { boxShadow: '0 0 10px red' } } }} />,
+    { createNodeMock },
   ).toJSON()
   expect(tree.props.style.boxShadow).toBe('0 0 10px red')
 })

--- a/src/components/photoshop/__snapshots__/spec.js.snap
+++ b/src/components/photoshop/__snapshots__/spec.js.snap
@@ -69,8 +69,6 @@ exports[`Photoshop renders correctly 1`] = `
     >
       <div
         onMouseDown={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
         style={
           Object {
             "MozBorderRadius": undefined,
@@ -211,8 +209,6 @@ exports[`Photoshop renders correctly 1`] = `
         <div
           className="hue-vertical"
           onMouseDown={[Function]}
-          onTouchMove={[Function]}
-          onTouchStart={[Function]}
           style={
             Object {
               "MozBorderRadius": undefined,

--- a/src/components/photoshop/spec.js
+++ b/src/components/photoshop/spec.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { red } from '../../helpers/color'
+import { createNodeMock } from '../../../support/createNodeMock'
 
 import Photoshop from './Photoshop'
 import PhotoshopButton from './PhotoshopButton'
@@ -14,6 +15,7 @@ import PhotoshopPreviews from './PhotoshopPreviews'
 test('Photoshop renders correctly', () => {
   const tree = renderer.create(
     <Photoshop { ...red } onAccept={ () => {} } onCancel={ () => {} } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -21,6 +23,7 @@ test('Photoshop renders correctly', () => {
 test('Photoshop renders custom styles correctly', () => {
   const tree = renderer.create(
     <Photoshop { ...red } styles={{ default: { picker: { boxShadow: '0 0 10px red' } } }} />,
+    { createNodeMock },
   ).toJSON()
   expect(tree.props.style.boxShadow).toBe('0 0 10px red')
 })

--- a/src/components/sketch/__snapshots__/spec.js.snap
+++ b/src/components/sketch/__snapshots__/spec.js.snap
@@ -34,8 +34,6 @@ exports[`Sketch renders correctly 1`] = `
   >
     <div
       onMouseDown={[Function]}
-      onTouchMove={[Function]}
-      onTouchStart={[Function]}
       style={
         Object {
           "MozBorderRadius": undefined,
@@ -199,8 +197,6 @@ exports[`Sketch renders correctly 1`] = `
           <div
             className="hue-horizontal"
             onMouseDown={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
             style={
               Object {
                 "MozBorderRadius": undefined,
@@ -359,8 +355,6 @@ exports[`Sketch renders correctly 1`] = `
           />
           <div
             onMouseDown={[Function]}
-            onTouchMove={[Function]}
-            onTouchStart={[Function]}
             style={
               Object {
                 "height": "100%",

--- a/src/components/sketch/spec.js
+++ b/src/components/sketch/spec.js
@@ -4,6 +4,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { mount } from 'enzyme'
 import color, { red } from '../../helpers/color'
+import { createNodeMock } from '../../../support/createNodeMock'
 // import canvas from 'canvas'
 
 import Sketch from './Sketch'
@@ -14,6 +15,7 @@ import { Swatch } from '../common'
 test('Sketch renders correctly', () => {
   const tree = renderer.create(
     <Sketch { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -56,6 +58,7 @@ test('Sketch with onSwatchHover events correctly', () => {
 test('Sketch renders custom styles correctly', () => {
   const tree = renderer.create(
     <Sketch styles={{ default: { picker: { boxShadow: 'none' } } }} />,
+    { createNodeMock },
   ).toJSON()
   expect(tree.props.style.boxShadow).toBe('none')
 })

--- a/src/components/slider/__snapshots__/spec.js.snap
+++ b/src/components/slider/__snapshots__/spec.js.snap
@@ -37,8 +37,6 @@ exports[`Slider renders correctly 1`] = `
       <div
         className="hue-horizontal"
         onMouseDown={[Function]}
-        onTouchMove={[Function]}
-        onTouchStart={[Function]}
         style={
           Object {
             "MozBorderRadius": undefined,

--- a/src/components/slider/spec.js
+++ b/src/components/slider/spec.js
@@ -3,6 +3,7 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
 import { red } from '../../helpers/color'
+import { createNodeMock } from '../../../support/createNodeMock'
 
 import Slider from './Slider'
 import SliderPointer from './SliderPointer'
@@ -12,6 +13,7 @@ import SliderSwatches from './SliderSwatches'
 test('Slider renders correctly', () => {
   const tree = renderer.create(
     <Slider { ...red } />,
+    { createNodeMock },
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })
@@ -19,6 +21,7 @@ test('Slider renders correctly', () => {
 test('Slider renders custom styles correctly', () => {
   const tree = renderer.create(
     <Slider styles={{ default: { wrap: { boxShadow: 'none' } } }} />,
+    { createNodeMock },
   ).toJSON()
   expect(tree.props.style.boxShadow).toBe('none')
 })

--- a/support/createNodeMock.js
+++ b/support/createNodeMock.js
@@ -1,0 +1,13 @@
+const noop = () => {}
+
+const createNodeMock = (element) => {
+  if (element.type === 'div') {
+    return {
+      addEventListener: noop
+    }
+  }
+
+  return null
+}
+
+export { createNodeMock }


### PR DESCRIPTION
This PR will resolve #581 

`e.preventDefault()` is not working properly on React's synthetic touch events.
As a workaround, touch event handlers are attached directly to DOM node.

https://github.com/facebook/react/issues/9809#issuecomment-414072263