### PR TITLE
Added disableColorType prop for chrome

### DIFF
--- a/src/components/chrome/Chrome.js
+++ b/src/components/chrome/Chrome.js
@@ -8,88 +8,105 @@ import ChromeFields from './ChromeFields'
 import ChromePointer from './ChromePointer'
 import ChromePointerCircle from './ChromePointerCircle'
 
-export const Chrome = ({ width, onChange, disableAlpha, rgb, hsl, hsv, hex, renderers,
-  styles: passedStyles = {}, className = '' }) => {
-  const styles = reactCSS(merge({
-    'default': {
-      picker: {
-        width,
-        background: '#fff',
-        borderRadius: '2px',
-        boxShadow: '0 0 2px rgba(0,0,0,.3), 0 4px 8px rgba(0,0,0,.3)',
-        boxSizing: 'initial',
-        fontFamily: 'Menlo',
+export const Chrome = ({
+  width,
+  onChange,
+  disableAlpha,
+  rgb,
+  hsl,
+  hsv,
+  hex,
+  renderers,
+  disableColorType,
+  styles: passedStyles = {},
+  className = '',
+}) => {
+  const styles = reactCSS(
+    merge(
+      {
+        default: {
+          picker: {
+            width,
+            background: '#fff',
+            borderRadius: '2px',
+            boxShadow: '0 0 2px rgba(0,0,0,.3), 0 4px 8px rgba(0,0,0,.3)',
+            boxSizing: 'initial',
+            fontFamily: 'Menlo',
+          },
+          saturation: {
+            width: '100%',
+            paddingBottom: '55%',
+            position: 'relative',
+            borderRadius: '2px 2px 0 0',
+            overflow: 'hidden',
+          },
+          Saturation: {
+            radius: '2px 2px 0 0',
+          },
+          body: {
+            padding: '16px 16px 12px',
+          },
+          controls: {
+            display: 'flex',
+          },
+          color: {
+            width: '32px',
+          },
+          swatch: {
+            marginTop: '6px',
+            width: '16px',
+            height: '16px',
+            borderRadius: '8px',
+            position: 'relative',
+            overflow: 'hidden',
+          },
+          active: {
+            absolute: '0px 0px 0px 0px',
+            borderRadius: '8px',
+            boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.1)',
+            background: `rgba(${ rgb.r }, ${ rgb.g }, ${ rgb.b }, ${ rgb.a })`,
+            zIndex: '2',
+          },
+          toggles: {
+            flex: '1',
+          },
+          hue: {
+            height: '10px',
+            position: 'relative',
+            marginBottom: '8px',
+          },
+          Hue: {
+            radius: '2px',
+          },
+          alpha: {
+            height: '10px',
+            position: 'relative',
+          },
+          Alpha: {
+            radius: '2px',
+          },
+        },
+        disableAlpha: {
+          color: {
+            width: '22px',
+          },
+          alpha: {
+            display: 'none',
+          },
+          hue: {
+            marginBottom: '0px',
+          },
+          swatch: {
+            width: '10px',
+            height: '10px',
+            marginTop: '0px',
+          },
+        },
       },
-      saturation: {
-        width: '100%',
-        paddingBottom: '55%',
-        position: 'relative',
-        borderRadius: '2px 2px 0 0',
-        overflow: 'hidden',
-      },
-      Saturation: {
-        radius: '2px 2px 0 0',
-      },
-      body: {
-        padding: '16px 16px 12px',
-      },
-      controls: {
-        display: 'flex',
-      },
-      color: {
-        width: '32px',
-      },
-      swatch: {
-        marginTop: '6px',
-        width: '16px',
-        height: '16px',
-        borderRadius: '8px',
-        position: 'relative',
-        overflow: 'hidden',
-      },
-      active: {
-        absolute: '0px 0px 0px 0px',
-        borderRadius: '8px',
-        boxShadow: 'inset 0 0 0 1px rgba(0,0,0,.1)',
-        background: `rgba(${ rgb.r }, ${ rgb.g }, ${ rgb.b }, ${ rgb.a })`,
-        zIndex: '2',
-      },
-      toggles: {
-        flex: '1',
-      },
-      hue: {
-        height: '10px',
-        position: 'relative',
-        marginBottom: '8px',
-      },
-      Hue: {
-        radius: '2px',
-      },
-      alpha: {
-        height: '10px',
-        position: 'relative',
-      },
-      Alpha: {
-        radius: '2px',
-      },
-    },
-    'disableAlpha': {
-      color: {
-        width: '22px',
-      },
-      alpha: {
-        display: 'none',
-      },
-      hue: {
-        marginBottom: '0px',
-      },
-      swatch: {
-        width: '10px',
-        height: '10px',
-        marginTop: '0px',
-      },
-    },
-  }, passedStyles), { disableAlpha })
+      passedStyles
+    ),
+    { disableAlpha }
+  )
 
   return (
     <div style={ styles.picker } className={ `chrome-picker ${ className }` }>
@@ -112,12 +129,7 @@ export const Chrome = ({ width, onChange, disableAlpha, rgb, hsl, hsv, hex, rend
           </div>
           <div style={ styles.toggles }>
             <div style={ styles.hue }>
-              <Hue
-                style={ styles.Hue }
-                hsl={ hsl }
-                pointer={ ChromePointer }
-                onChange={ onChange }
-              />
+              <Hue style={ styles.Hue } hsl={ hsl } pointer={ ChromePointer } onChange={ onChange } />
             </div>
             <div style={ styles.alpha }>
               <Alpha
@@ -131,13 +143,15 @@ export const Chrome = ({ width, onChange, disableAlpha, rgb, hsl, hsv, hex, rend
             </div>
           </div>
         </div>
-        <ChromeFields
-          rgb={ rgb }
-          hsl={ hsl }
-          hex={ hex }
-          onChange={ onChange }
-          disableAlpha={ disableAlpha }
-        />
+        {disableColorType ? null : (
+          <ChromeFields
+            rgb={ rgb }
+            hsl={ hsl }
+            hex={ hex }
+            onChange={ onChange }
+            disableAlpha={ disableAlpha }
+          />
+        )}
       </div>
     </div>
   )
@@ -147,11 +161,13 @@ Chrome.propTypes = {
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   disableAlpha: PropTypes.bool,
   styles: PropTypes.object,
+  disableColorType: PropTypes.bool,
 }
 
 Chrome.defaultProps = {
   width: 225,
   disableAlpha: false,
+  disableColorType: false,
   styles: {},
 }
 

--- a/src/components/chrome/__snapshots__/spec.js.snap
+++ b/src/components/chrome/__snapshots__/spec.js.snap
@@ -800,3 +800,29 @@ exports[`ChromePointerCircle renders correctly 1`] = `
   }
 />
 `;
+
+exports[`disableColorType prop renders correctly 1`] = `
+<div
+  style={
+    Object {
+      "MozBorderRadius": "6px",
+      "MozBoxShadow": "inset 0 0 0 1px #fff",
+      "MozTransform": "translate(-6px, -6px)",
+      "OBorderRadius": "6px",
+      "OBoxShadow": "inset 0 0 0 1px #fff",
+      "OTransform": "translate(-6px, -6px)",
+      "WebkitBorderRadius": "6px",
+      "WebkitBoxShadow": "inset 0 0 0 1px #fff",
+      "WebkitTransform": "translate(-6px, -6px)",
+      "borderRadius": "6px",
+      "boxShadow": "inset 0 0 0 1px #fff",
+      "height": "12px",
+      "msBorderRadius": "6px",
+      "msBoxShadow": "inset 0 0 0 1px #fff",
+      "msTransform": "translate(-6px, -6px)",
+      "transform": "translate(-6px, -6px)",
+      "width": "12px",
+    }
+  }
+/>
+`;

--- a/src/components/chrome/spec.js
+++ b/src/components/chrome/spec.js
@@ -82,3 +82,10 @@ test('Chrome renders correctly with width', () => {
   ).toJSON()
   expect(tree.props.style.width).toBe(300)
 });
+
+test('disableColorType prop renders correctly', () => {
+  const tree = renderer.create(
+    <ChromePointerCircle disableColorType={true} />,
+  ).toJSON()
+  expect(tree).toMatchSnapshot()
+})


### PR DESCRIPTION
Thought it would be a nice add-on to remove the color type selector in the chrome picker as most of my users don't really care what format the color is in as they will mostly select color with the UI. This adds a prop of `disableColorType` that defaults to false, and when true renders the following:

![image](https://user-images.githubusercontent.com/538485/54885554-d1c34c00-4e53-11e9-8ffd-d98f1e1d9df4.png)

Also just to note: My prettier removed the quotes from the styles object keys of `default` and `disableAlpha`, as well as reformatted the params, maybe easier to check out the diff disregarding the whitespace: https://github.com/casesandberg/react-color/pull/600/files?w=1