### PR TITLE
Fix: Last SliderPicker swatch unselectable when passing a hex code color.

### DIFF
--- a/src/components/slider/SliderSwatches.js
+++ b/src/components/slider/SliderSwatches.js
@@ -21,14 +21,17 @@ export const SliderSwatches = ({ onClick, hsl }) => {
     },
   })
 
+  // Acceptible difference in floating point equality
+  const epsilon = 0.1
+
   return (
     <div style={ styles.swatches }>
       <div style={ styles.swatch }>
         <SliderSwatch
           hsl={ hsl }
           offset=".80"
-          active={ Math.round(hsl.l * 100) / 100 === 0.80
-            && Math.round(hsl.s * 100) / 100 === 0.50 }
+          active={ Math.abs(hsl.l - 0.80) < epsilon
+            && Math.abs(hsl.s - 0.50) < epsilon }
           onClick={ onClick }
           first
         />
@@ -37,8 +40,8 @@ export const SliderSwatches = ({ onClick, hsl }) => {
         <SliderSwatch
           hsl={ hsl }
           offset=".65"
-          active={ Math.round(hsl.l * 100) / 100 === 0.65
-            && Math.round(hsl.s * 100) / 100 === 0.50 }
+          active={ Math.abs(hsl.l - 0.65) < epsilon
+            && Math.abs(hsl.s - 0.50) < epsilon }
           onClick={ onClick }
         />
       </div>
@@ -46,8 +49,8 @@ export const SliderSwatches = ({ onClick, hsl }) => {
         <SliderSwatch
           hsl={ hsl }
           offset=".50"
-          active={ Math.round(hsl.l * 100) / 100 === 0.50
-             && Math.round(hsl.s * 100) / 100 === 0.50 }
+          active={ Math.abs(hsl.l - 0.50) < epsilon
+            && Math.abs(hsl.s - 0.50) < epsilon }
           onClick={ onClick }
         />
       </div>
@@ -55,8 +58,8 @@ export const SliderSwatches = ({ onClick, hsl }) => {
         <SliderSwatch
           hsl={ hsl }
           offset=".35"
-          active={ Math.round(hsl.l * 100) / 100 === 0.35
-            && Math.round(hsl.s * 100) / 100 === 0.50 }
+          active={ Math.abs(hsl.l - 0.35) < epsilon
+            && Math.abs(hsl.s - 0.50) < epsilon }
           onClick={ onClick }
         />
       </div>
@@ -64,8 +67,8 @@ export const SliderSwatches = ({ onClick, hsl }) => {
         <SliderSwatch
           hsl={ hsl }
           offset=".20"
-          active={ Math.round(hsl.l * 100) / 100 === 0.20
-            && Math.round(hsl.s * 100) / 100 === 0.50 }
+          active={ Math.abs(hsl.l - 0.20) < epsilon
+            && Math.abs(hsl.s - 0.50) < epsilon }
           onClick={ onClick }
           last
         />


### PR DESCRIPTION
## Problem
- `tinycolor2` makes lossy conversion of hex to hsl
- SliderSwatches determines if it is selected by equality checking the saturation and luminance values of the color prop against constants.

So

- When a swatch is selected, its value is returned to the rendering component.
- If that internal color value is converted to HEX and stored externally, that HEX is then passed back to the SliderSwatches component as the color prop. This is then used for determination of the active swatch.
- The lossy conversions result in an incorrect equality assessment, apparently always on the rightmost swatch.

See example at https://runkit.com/embed/w73rddbxegzl

## Solution
- This pull request modifies the active determination logic in SliderSwatches
- It compares absolute value of the difference between the color prop's s & l and the constants to epsilon, instead of using Math.round and equality checking

## Notes
- What should epsilon be? I used 0.1, and it seems to work.


### Addresses
- #502
- #28
- More?
