### PR TITLE
[Twitter] Fix Broken Input

### DIFF
--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -141,6 +141,7 @@ export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
         }) }
         <div style={ styles.hash }>#</div>
         <EditableInput
+          label={null}
           style={{ input: styles.input }}
           value={ hex.replace('#', '') }
           onChange={ handleChange }


### PR DESCRIPTION
`<EditableInput />` uses a label to prefix the object name in onChange. Unless label it set to false it will return `{undefined: value}` which was causing the input to not trigger color changes. 

Fixes https://github.com/casesandberg/react-color/issues/609