### PR TITLE
fix(BlockPicker): fixes blockpicker input not working

### DIFF
--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -74,7 +74,7 @@ export class EditableInput extends (PureComponent || Component) {
   }
 
   setUpdatedValue(value, e) {
-    const onChangeValue = this.props.label !== null ? this.getValueObjectWithLabel(value) : value
+    const onChangeValue = this.props.label ? this.getValueObjectWithLabel(value) : value
     this.props.onChange && this.props.onChange(onChangeValue, e)
 
     const isPercentage = getIsPercentage(e.target.value)


### PR DESCRIPTION
setUpdatedValue on EditableInput had a check that checked props.label not being null.
In BlockPicker case label was undefined which caused the onChange to be called with
and object instead of hex string. fixes #512 