### PR TITLE
Support for CSS color names for the CirclePicker component

### DIFF
--- a/src/components/circle/Circle.js
+++ b/src/components/circle/Circle.js
@@ -7,6 +7,7 @@ import * as material from 'material-colors'
 
 import { ColorWrap } from '../common'
 import CircleSwatch from './CircleSwatch'
+import color from '../../helpers/color'
 
 export const Circle = ({ width, onChange, onSwatchHover, colors, hex, circleSize,
   styles: passedStyles = {}, circleSpacing, className = '' }) => {
@@ -32,7 +33,7 @@ export const Circle = ({ width, onChange, onSwatchHover, colors, hex, circleSize
           color={ c }
           onClick={ handleChange }
           onSwatchHover={ onSwatchHover }
-          active={ hex === c.toLowerCase() }
+          active={ hex === color.toState(c.toLowerCase()).hex }
           circleSize={ circleSize }
           circleSpacing={ circleSpacing }
         />


### PR DESCRIPTION
With this changes now I can use arrays such as `["White","Black","Red","Orange","Yellow","Green","Blue","Indigo","Purple"]` and have nice titles for divs with circles.
