### PR TITLE
componentWillReceiveProps -> componentDidUpdate

### DIFF
--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -25,10 +25,10 @@ export class EditableInput extends (PureComponent || Component) {
     }
   }
 
-  componentDidUpdate(prevProps) {
+  componentDidUpdate(prevProps, prevState) {
     if (
       this.props.value !== this.state.value &&
-      prevProps.value !== this.props.value
+      (prevProps.value !== this.props.value || prevState.value !== this.state.value)
     ) {
       if (this.input === document.activeElement) {
         this.setState({ blurValue: String(this.props.value).toUpperCase() })

--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -25,13 +25,15 @@ export class EditableInput extends (PureComponent || Component) {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    const input = this.input
-    if (nextProps.value !== this.state.value) {
-      if (input === document.activeElement) {
-        this.setState({ blurValue: String(nextProps.value).toUpperCase() })
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.value !== this.state.value &&
+      prevProps.value !== this.props.value
+    ) {
+      if (this.input === document.activeElement) {
+        this.setState({ blurValue: String(this.props.value).toUpperCase() })
       } else {
-        this.setState({ value: String(nextProps.value).toUpperCase(), blurValue: !this.state.blurValue && String(nextProps.value).toUpperCase() })
+        this.setState({ value: String(this.props.value).toUpperCase(), blurValue: !this.state.blurValue && String(this.props.value).toUpperCase() })
       }
     }
   }


### PR DESCRIPTION
Instead of using `componentDidUpdate`, you could also update this component to use `getDerivedStateFromProps` if you are willing to put `this.input` in state instead:

```js
static getDerivedStateFromProps(props, state) {
  if (props.value !== state.value) {
    if (state.input === document.activeElement) {
      return { blurValue: String(props.value).toUpperCase() }
    } else {
      return { value: String(props.value).toUpperCase(), blurValue: !state.blurValue && String(props.value).toUpperCase() }
    }
  }
}

...

ref={ input => this.setState({ input }) }
```

Let me know if you all prefer one over the other. 

Begin #634