### PR TITLE
Attempt to solve disappearing CirclePicker Swatches on matching background

### DIFF
--- a/src/components/circle/CircleSwatch.js
+++ b/src/components/circle/CircleSwatch.js
@@ -4,7 +4,7 @@ import reactCSS, { handleHover } from 'reactcss'
 import { Swatch } from '../common'
 
 export const CircleSwatch = ({ color, onClick, onSwatchHover, hover, active,
-  circleSize, circleSpacing }) => {
+  circleSize, circleSpacing, borderColor }) => {
   const styles = reactCSS({
     'default': {
       swatch: {
@@ -20,6 +20,7 @@ export const CircleSwatch = ({ color, onClick, onSwatchHover, hover, active,
         background: 'transparent',
         boxShadow: `inset 0 0 0 ${ circleSize / 2 }px ${ color }`,
         transition: '100ms box-shadow ease',
+        border: `1px ${borderColor} solid`,
       },
     },
     'hover': {
@@ -29,7 +30,7 @@ export const CircleSwatch = ({ color, onClick, onSwatchHover, hover, active,
     },
     'active': {
       Swatch: {
-        boxShadow: `inset 0 0 0 3px ${ color }`,
+        boxShadow: `inset 0 0 0 3px ${color}, inset 0 0 0 4px ${borderColor}`,
       },
     },
   }, { hover, active })
@@ -41,7 +42,7 @@ export const CircleSwatch = ({ color, onClick, onSwatchHover, hover, active,
         color={ color }
         onClick={ onClick }
         onHover={ onSwatchHover }
-        focusStyle={{ boxShadow: `${ styles.Swatch.boxShadow }, 0 0 5px ${ color }` }}
+        focusStyle={{ boxShadow: `${styles.Swatch.boxShadow}, 0 0 5px ${borderColor}` }}
       />
     </div>
   )
@@ -50,6 +51,7 @@ export const CircleSwatch = ({ color, onClick, onSwatchHover, hover, active,
 CircleSwatch.defaultProps = {
   circleSize: 28,
   circleSpacing: 14,
+  borderColor: '#e0e0e0'
 }
 
 export default handleHover(CircleSwatch)


### PR DESCRIPTION
@casesandberg This is just an option for solving this problem. I'm submitting this to have something to discuss.

Also, the storybook doesn't seem to have an option to change the colors, so I had to edit the story.js file to actually see a white circle color swatch. Maybe there is a better way to do this?

Addresses Issue #530 