### PR TITLE
tinycolor from rgb instead of hex

### DIFF
--- a/src/helpers/color.js
+++ b/src/helpers/color.js
@@ -23,7 +23,7 @@ export const simpleCheckForValidColor = (data) => {
 }
 
 export const toState = (data, oldHue) => {
-  const color = data.hex ? tinycolor(data.hex) : tinycolor(data)
+  const color = data.rgb ? tinycolor(data.rgb) : tinycolor(data)
   const hsl = color.toHsl()
   const hsv = color.toHsv()
   const rgb = color.toRgb()


### PR DESCRIPTION
We need to tinycolor rgb instead of hex to let use transparent.
When we change transparent nothing happens. Because we use hex (which doesn't include alpha field).