### PR TITLE
Change the circle pointer color to black on light colors

### DIFF
--- a/src/components/chrome/ChromePointerCircle.js
+++ b/src/components/chrome/ChromePointerCircle.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import reactCSS from 'reactcss'
 
-export const ChromePointerCircle = () => {
+export const ChromePointerCircle = ({hsl}) => {
   const styles = reactCSS({
     'default': {
       picker: {
@@ -12,7 +12,12 @@ export const ChromePointerCircle = () => {
         transform: 'translate(-6px, -6px)',
       },
     },
-  })
+    'black-outline': {
+      picker: {
+        boxShadow: 'inset 0 0 0 1px #000',
+      },
+    },
+  }, { 'black-outline': hsl.l > 0.5 })
 
   return (
     <div style={ styles.picker } />

--- a/src/components/chrome/spec.js
+++ b/src/components/chrome/spec.js
@@ -64,7 +64,7 @@ test('ChromePointer renders correctly', () => {
 
 test('ChromePointerCircle renders correctly', () => {
   const tree = renderer.create(
-    <ChromePointerCircle />,
+    <ChromePointerCircle  { ...red } />,
   ).toJSON()
   expect(tree).toMatchSnapshot()
 })


### PR DESCRIPTION
This makes the behavior the same as the PhotoshopPointerCircle. Without this it is difficult to
see the circle when the selected color is white.