### PR TITLE
remove isValidHex validation from Swatches

### DIFF
--- a/src/components/swatches/Swatches.js
+++ b/src/components/swatches/Swatches.js
@@ -30,12 +30,7 @@ export const Swatches = ({ width, height, onChange, onSwatchHover, colors, hex,
     },
   }, passedStyles))
 
-  const handleChange = (data, e) => {
-    color.isValidHex(data) && onChange({
-      hex: data,
-      source: 'hex',
-    }, e)
-  }
+  const handleChange = (data, e) => onChange({ hex: data, source: 'hex' }, e)
 
   return (
     <div style={ styles.picker } className={ `swatches-picker ${ className }` }>

--- a/src/components/swatches/Swatches.js
+++ b/src/components/swatches/Swatches.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
 import map from 'lodash/map'
 import merge from 'lodash/merge'
-import color from '../../helpers/color'
 import * as material from 'material-colors'
 
 import { ColorWrap, Raised } from '../common'


### PR DESCRIPTION
This changes `Swatches` to be consistent with `Github` and `Circle`. 

This fixes https://github.com/casesandberg/react-color/issues/488 and makes it up to the user to control the color values via props, letting you use hex8 or rgba in these components (if your use case supports it) since the component itself does not need to validate an end-user hex6 text input.

It could also make sense to have the `onChange` property of these components return a  color string value instead of `color.hex` but that would be a breaking change to the interface.  May be better for this to just be an undocumented feature for those of us that need it? Meaning that these components are "dumb" and will pass through whatever values we feed in. 