### PR TITLE
Fix transparent color

### DIFF
--- a/src/helpers/color.js
+++ b/src/helpers/color.js
@@ -45,6 +45,9 @@ export const toState = (data, oldHue) => {
 }
 
 export const isValidHex = (hex) => {
+  if (hex === 'transparent') {
+    return true
+  }
   // disable hex4 and hex8
   const lh = (String(hex).charAt(0) === '#') ? 1 : 0
   return hex.length !== (4 + lh) && hex.length < (7 + lh) && tinycolor(hex).isValid()

--- a/src/helpers/spec.js
+++ b/src/helpers/spec.js
@@ -129,6 +129,10 @@ describe('helpers/color', () => {
       expect(color.isValidHex('FFFFFF')).toBeTruthy()
     })
 
+    test('allow transparent color', () => {
+      expect(color.isValidHex('transparent')).toBeTruthy()
+    })
+
     test('does not allow non-hex characters', () => {
       expect(color.isValidHex('gggggg')).toBeFalsy()
     })


### PR DESCRIPTION
thinking about correcting the problem with the transparent color without proposing changes in what had already been defined (such as disable hex4 and hex8), I edited the validation function to pragmatically allow the transparent color, thus avoiding side effects