### PR TITLE
TwitterPicker - hideHexInput prop to hide hex EditableInput

### DIFF
--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -7,7 +7,7 @@ import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Swatch } from '../common'
 
-export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
+export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle, hideHexInput,
   styles: passedStyles = {}, className = '' }) => {
   const styles = reactCSS(merge({
     'default': {
@@ -119,34 +119,32 @@ export const Twitter = ({ onChange, onSwatchHover, hex, colors, width, triangle,
   }
 
   return (
-    <div style={ styles.card } className={ `twitter-picker ${ className }` }>
-      <div style={ styles.triangleShadow } />
-      <div style={ styles.triangle } />
+    <div style={styles.card} className={`twitter-picker ${className}`}>
+      <div style={styles.triangleShadow} />
+      <div style={styles.triangle} />
 
-      <div style={ styles.body }>
-        { map(colors, (c, i) => {
-          return (
-            <Swatch
-              key={ i }
-              color={ c }
-              hex={ c }
-              style={ styles.swatch }
-              onClick={ handleChange }
-              onHover={ onSwatchHover }
-              focusStyle={{
-                boxShadow: `0 0 4px ${ c }`,
-              }}
-            />
-          )
-        }) }
-        <div style={ styles.hash }>#</div>
-        <EditableInput
-          label={null}
-          style={{ input: styles.input }}
-          value={ hex.replace('#', '') }
-          onChange={ handleChange }
-        />
-        <div style={ styles.clear } />
+      <div style={styles.body}>
+        {map(colors, (c, i) => (
+          <Swatch
+            key={i}
+            color={c}
+            hex={c}
+            style={styles.swatch}
+            onClick={handleChange}
+            onHover={onSwatchHover}
+            focusStyle={{
+              boxShadow: `0 0 4px ${c}`,
+            }}
+          />
+        ))}
+        {hideHexInput ?
+          <div /> : (
+            <div className="hexInputContainer">
+              <div style={styles.hash}>#</div>
+              <EditableInput label={null} style={{ input: styles.input }} value={hex.replace('#', '')} onChange={handleChange} />
+            </div>
+          )}
+        <div style={styles.clear} />
       </div>
     </div>
   )
@@ -157,6 +155,7 @@ Twitter.propTypes = {
   triangle: PropTypes.oneOf(['hide', 'top-left', 'top-right']),
   colors: PropTypes.arrayOf(PropTypes.string),
   styles: PropTypes.object,
+  hideHexInput: PropTypes.bool,
 }
 
 Twitter.defaultProps = {
@@ -165,6 +164,7 @@ Twitter.defaultProps = {
     '#ABB8C3', '#EB144C', '#F78DA7', '#9900EF'],
   triangle: 'top-left',
   styles: {},
+  hideHexInput: false,
 }
 
 export default ColorWrap(Twitter)

--- a/src/components/twitter/__snapshots__/spec.js.snap
+++ b/src/components/twitter/__snapshots__/spec.js.snap
@@ -336,65 +336,69 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
       />
     </span>
     <div
-      style={
-        Object {
-          "MozBorderRadius": "4px 0 0 4px",
-          "OBorderRadius": "4px 0 0 4px",
-          "WebkitBorderRadius": "4px 0 0 4px",
-          "WebkitJustifyContent": "center",
-          "alignItems": "center",
-          "background": "#F0F0F0",
-          "borderRadius": "4px 0 0 4px",
-          "color": "#98A1A4",
-          "display": "flex",
-          "float": "left",
-          "height": "30px",
-          "justifyContent": "center",
-          "msBorderRadius": "4px 0 0 4px",
-          "width": "30px",
-        }
-      }
+      className="hexInputContainer"
     >
-      #
-    </div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-        }
-      }
-    >
-      <input
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyDown={[Function]}
-        placeholder={undefined}
-        spellCheck="false"
+      <div
         style={
           Object {
-            "MozBorderRadius": "0 4px 4px 0",
-            "MozBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "OBorderRadius": "0 4px 4px 0",
-            "OBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "WebkitBorderRadius": "0 4px 4px 0",
-            "WebkitBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "border": "0px",
-            "borderRadius": "0 4px 4px 0",
-            "boxShadow": "inset 0 0 0 1px #F0F0F0",
-            "boxSizing": "content-box",
-            "color": "#666",
+            "MozBorderRadius": "4px 0 0 4px",
+            "OBorderRadius": "4px 0 0 4px",
+            "WebkitBorderRadius": "4px 0 0 4px",
+            "WebkitJustifyContent": "center",
+            "alignItems": "center",
+            "background": "#F0F0F0",
+            "borderRadius": "4px 0 0 4px",
+            "color": "#98A1A4",
+            "display": "flex",
             "float": "left",
-            "fontSize": "14px",
-            "height": "28px",
-            "msBorderRadius": "0 4px 4px 0",
-            "msBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "outline": "none",
-            "paddingLeft": "8px",
-            "width": "100px",
+            "height": "30px",
+            "justifyContent": "center",
+            "msBorderRadius": "4px 0 0 4px",
+            "width": "30px",
           }
         }
-        value="22194D"
-      />
+      >
+        #
+      </div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
+      >
+        <input
+          onBlur={[Function]}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder={undefined}
+          spellCheck="false"
+          style={
+            Object {
+              "MozBorderRadius": "0 4px 4px 0",
+              "MozBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "OBorderRadius": "0 4px 4px 0",
+              "OBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "WebkitBorderRadius": "0 4px 4px 0",
+              "WebkitBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "border": "0px",
+              "borderRadius": "0 4px 4px 0",
+              "boxShadow": "inset 0 0 0 1px #F0F0F0",
+              "boxSizing": "content-box",
+              "color": "#666",
+              "float": "left",
+              "fontSize": "14px",
+              "height": "28px",
+              "msBorderRadius": "0 4px 4px 0",
+              "msBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "outline": "none",
+              "paddingLeft": "8px",
+              "width": "100px",
+            }
+          }
+          value="22194D"
+        />
+      </div>
     </div>
     <div
       style={
@@ -745,65 +749,69 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
       />
     </span>
     <div
-      style={
-        Object {
-          "MozBorderRadius": "4px 0 0 4px",
-          "OBorderRadius": "4px 0 0 4px",
-          "WebkitBorderRadius": "4px 0 0 4px",
-          "WebkitJustifyContent": "center",
-          "alignItems": "center",
-          "background": "#F0F0F0",
-          "borderRadius": "4px 0 0 4px",
-          "color": "#98A1A4",
-          "display": "flex",
-          "float": "left",
-          "height": "30px",
-          "justifyContent": "center",
-          "msBorderRadius": "4px 0 0 4px",
-          "width": "30px",
-        }
-      }
+      className="hexInputContainer"
     >
-      #
-    </div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-        }
-      }
-    >
-      <input
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyDown={[Function]}
-        placeholder={undefined}
-        spellCheck="false"
+      <div
         style={
           Object {
-            "MozBorderRadius": "0 4px 4px 0",
-            "MozBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "OBorderRadius": "0 4px 4px 0",
-            "OBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "WebkitBorderRadius": "0 4px 4px 0",
-            "WebkitBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "border": "0px",
-            "borderRadius": "0 4px 4px 0",
-            "boxShadow": "inset 0 0 0 1px #F0F0F0",
-            "boxSizing": "content-box",
-            "color": "#666",
+            "MozBorderRadius": "4px 0 0 4px",
+            "OBorderRadius": "4px 0 0 4px",
+            "WebkitBorderRadius": "4px 0 0 4px",
+            "WebkitJustifyContent": "center",
+            "alignItems": "center",
+            "background": "#F0F0F0",
+            "borderRadius": "4px 0 0 4px",
+            "color": "#98A1A4",
+            "display": "flex",
             "float": "left",
-            "fontSize": "14px",
-            "height": "28px",
-            "msBorderRadius": "0 4px 4px 0",
-            "msBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "outline": "none",
-            "paddingLeft": "8px",
-            "width": "100px",
+            "height": "30px",
+            "justifyContent": "center",
+            "msBorderRadius": "4px 0 0 4px",
+            "width": "30px",
           }
         }
-        value="22194D"
-      />
+      >
+        #
+      </div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
+      >
+        <input
+          onBlur={[Function]}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder={undefined}
+          spellCheck="false"
+          style={
+            Object {
+              "MozBorderRadius": "0 4px 4px 0",
+              "MozBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "OBorderRadius": "0 4px 4px 0",
+              "OBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "WebkitBorderRadius": "0 4px 4px 0",
+              "WebkitBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "border": "0px",
+              "borderRadius": "0 4px 4px 0",
+              "boxShadow": "inset 0 0 0 1px #F0F0F0",
+              "boxSizing": "content-box",
+              "color": "#666",
+              "float": "left",
+              "fontSize": "14px",
+              "height": "28px",
+              "msBorderRadius": "0 4px 4px 0",
+              "msBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "outline": "none",
+              "paddingLeft": "8px",
+              "width": "100px",
+            }
+          }
+          value="22194D"
+        />
+      </div>
     </div>
     <div
       style={
@@ -1154,65 +1162,69 @@ exports[`Twitter renders correctly 1`] = `
       />
     </span>
     <div
-      style={
-        Object {
-          "MozBorderRadius": "4px 0 0 4px",
-          "OBorderRadius": "4px 0 0 4px",
-          "WebkitBorderRadius": "4px 0 0 4px",
-          "WebkitJustifyContent": "center",
-          "alignItems": "center",
-          "background": "#F0F0F0",
-          "borderRadius": "4px 0 0 4px",
-          "color": "#98A1A4",
-          "display": "flex",
-          "float": "left",
-          "height": "30px",
-          "justifyContent": "center",
-          "msBorderRadius": "4px 0 0 4px",
-          "width": "30px",
-        }
-      }
+      className="hexInputContainer"
     >
-      #
-    </div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-        }
-      }
-    >
-      <input
-        onBlur={[Function]}
-        onChange={[Function]}
-        onKeyDown={[Function]}
-        placeholder={undefined}
-        spellCheck="false"
+      <div
         style={
           Object {
-            "MozBorderRadius": "0 4px 4px 0",
-            "MozBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "OBorderRadius": "0 4px 4px 0",
-            "OBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "WebkitBorderRadius": "0 4px 4px 0",
-            "WebkitBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "border": "0px",
-            "borderRadius": "0 4px 4px 0",
-            "boxShadow": "inset 0 0 0 1px #F0F0F0",
-            "boxSizing": "content-box",
-            "color": "#666",
+            "MozBorderRadius": "4px 0 0 4px",
+            "OBorderRadius": "4px 0 0 4px",
+            "WebkitBorderRadius": "4px 0 0 4px",
+            "WebkitJustifyContent": "center",
+            "alignItems": "center",
+            "background": "#F0F0F0",
+            "borderRadius": "4px 0 0 4px",
+            "color": "#98A1A4",
+            "display": "flex",
             "float": "left",
-            "fontSize": "14px",
-            "height": "28px",
-            "msBorderRadius": "0 4px 4px 0",
-            "msBoxShadow": "inset 0 0 0 1px #F0F0F0",
-            "outline": "none",
-            "paddingLeft": "8px",
-            "width": "100px",
+            "height": "30px",
+            "justifyContent": "center",
+            "msBorderRadius": "4px 0 0 4px",
+            "width": "30px",
           }
         }
-        value="22194D"
-      />
+      >
+        #
+      </div>
+      <div
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
+      >
+        <input
+          onBlur={[Function]}
+          onChange={[Function]}
+          onKeyDown={[Function]}
+          placeholder={undefined}
+          spellCheck="false"
+          style={
+            Object {
+              "MozBorderRadius": "0 4px 4px 0",
+              "MozBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "OBorderRadius": "0 4px 4px 0",
+              "OBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "WebkitBorderRadius": "0 4px 4px 0",
+              "WebkitBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "border": "0px",
+              "borderRadius": "0 4px 4px 0",
+              "boxShadow": "inset 0 0 0 1px #F0F0F0",
+              "boxSizing": "content-box",
+              "color": "#666",
+              "float": "left",
+              "fontSize": "14px",
+              "height": "28px",
+              "msBorderRadius": "0 4px 4px 0",
+              "msBoxShadow": "inset 0 0 0 1px #F0F0F0",
+              "outline": "none",
+              "paddingLeft": "8px",
+              "width": "100px",
+            }
+          }
+          value="22194D"
+        />
+      </div>
     </div>
     <div
       style={

--- a/src/components/twitter/spec.js
+++ b/src/components/twitter/spec.js
@@ -63,3 +63,12 @@ test('Twitter with onSwatchHover events correctly', () => {
 
   expect(hoverSpy).toHaveBeenCalled()
 })
+
+test('Twitter with "hideHexInput" hides hex input', () => {
+  const tree = mount(<Twitter {...red} hideHexInput />)
+  expect(tree.props().hideHexInput).toEqual(true)
+  expect(tree.find('.hexInputContainer')).toHaveLength(0)
+  tree.setProps({ hideHexInput: false })
+  expect(tree.props().hideHexInput).toEqual(false)
+  expect(tree.find('.hexInputContainer')).toHaveLength(1)
+})


### PR DESCRIPTION
This PR adds a new prop to TwitterPicker `hideHexInput`. 
All it does is to hide that input if the value is truthy. This is useful when the user doesn't want to allow for custom hex but only select from the predefined ones. 