### PR TITLE
fix(EditableInput): a11y - form elements must have labels

### DIFF
--- a/src/components/block/__snapshots__/spec.js.snap
+++ b/src/components/block/__snapshots__/spec.js.snap
@@ -358,6 +358,7 @@ exports[`Block \`triangle="hide"\` 1`] = `
       }
     >
       <input
+        id="rc-editable-input-4"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -749,6 +750,7 @@ exports[`Block renders correctly 1`] = `
       }
     >
       <input
+        id="rc-editable-input-1"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}

--- a/src/components/chrome/__snapshots__/spec.js.snap
+++ b/src/components/chrome/__snapshots__/spec.js.snap
@@ -518,6 +518,7 @@ exports[`Chrome renders correctly 1`] = `
             }
           >
             <input
+              id="rc-editable-input-1"
               onBlur={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -545,7 +546,8 @@ exports[`Chrome renders correctly 1`] = `
               }
               value="#22194D"
             />
-            <span
+            <label
+              htmlFor="rc-editable-input-1"
               onMouseDown={[Function]}
               style={
                 Object {
@@ -560,7 +562,7 @@ exports[`Chrome renders correctly 1`] = `
               }
             >
               hex
-            </span>
+            </label>
           </div>
         </div>
       </div>
@@ -654,6 +656,7 @@ exports[`ChromeFields renders correctly 1`] = `
         }
       >
         <input
+          id="rc-editable-input-3"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -681,7 +684,8 @@ exports[`ChromeFields renders correctly 1`] = `
           }
           value="#FF0000"
         />
-        <span
+        <label
+          htmlFor="rc-editable-input-3"
           onMouseDown={[Function]}
           style={
             Object {
@@ -696,7 +700,7 @@ exports[`ChromeFields renders correctly 1`] = `
           }
         >
           hex
-        </span>
+        </label>
       </div>
     </div>
   </div>

--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -12,6 +12,8 @@ const VALID_KEY_CODES = [
 const isValidKeyCode = keyCode => VALID_KEY_CODES.indexOf(keyCode) > -1
 const getNumberValue = value => Number(String(value).replace(/%/g, ''))
 
+let idCounter = 1
+
 export class EditableInput extends (PureComponent || Component) {
   constructor(props) {
     super()
@@ -20,6 +22,8 @@ export class EditableInput extends (PureComponent || Component) {
       value: String(props.value).toUpperCase(),
       blurValue: String(props.value).toUpperCase(),
     }
+
+    this.inputId = `rc-editable-input-${idCounter++}`
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -130,6 +134,7 @@ export class EditableInput extends (PureComponent || Component) {
     return (
       <div style={ styles.wrap }>
         <input
+          id={ this.inputId }
           style={ styles.input }
           ref={ input => this.input = input }
           value={ this.state.value }
@@ -140,9 +145,13 @@ export class EditableInput extends (PureComponent || Component) {
           spellCheck="false"
         />
         { this.props.label && !this.props.hideLabel ? (
-          <span style={ styles.label } onMouseDown={ this.handleMouseDown }>
+          <label
+            htmlFor={ this.inputId }
+            style={ styles.label }
+            onMouseDown={ this.handleMouseDown }
+          >
             { this.props.label }
-          </span>
+          </label>
         ) : null }
       </div>
     )

--- a/src/components/common/__snapshots__/spec.js.snap
+++ b/src/components/common/__snapshots__/spec.js.snap
@@ -191,6 +191,7 @@ exports[`EditableInput renders correctly 1`] = `
   }
 >
   <input
+    id="rc-editable-input-1"
     onBlur={[Function]}
     onChange={[Function]}
     onKeyDown={[Function]}
@@ -199,12 +200,13 @@ exports[`EditableInput renders correctly 1`] = `
     style={Object {}}
     value="UNDEFINED"
   />
-  <span
+  <label
+    htmlFor="rc-editable-input-1"
     onMouseDown={[Function]}
     style={Object {}}
   >
     Hex
-  </span>
+  </label>
 </div>
 `;
 

--- a/src/components/compact/__snapshots__/spec.js.snap
+++ b/src/components/compact/__snapshots__/spec.js.snap
@@ -1647,6 +1647,7 @@ exports[`Compact renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-1"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -1667,7 +1668,8 @@ exports[`Compact renders correctly 1`] = `
             }
             value="#22194D"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-1"
             onMouseDown={[Function]}
             style={
               Object {
@@ -1676,7 +1678,7 @@ exports[`Compact renders correctly 1`] = `
             }
           >
             hex
-          </span>
+          </label>
         </div>
         <div
           style={
@@ -1691,6 +1693,7 @@ exports[`Compact renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-2"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -1711,7 +1714,8 @@ exports[`Compact renders correctly 1`] = `
             }
             value="34"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-2"
             onMouseDown={[Function]}
             style={
               Object {
@@ -1726,7 +1730,7 @@ exports[`Compact renders correctly 1`] = `
             }
           >
             r
-          </span>
+          </label>
         </div>
         <div
           style={
@@ -1741,6 +1745,7 @@ exports[`Compact renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-3"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -1761,7 +1766,8 @@ exports[`Compact renders correctly 1`] = `
             }
             value="25"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-3"
             onMouseDown={[Function]}
             style={
               Object {
@@ -1776,7 +1782,7 @@ exports[`Compact renders correctly 1`] = `
             }
           >
             g
-          </span>
+          </label>
         </div>
         <div
           style={
@@ -1791,6 +1797,7 @@ exports[`Compact renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-4"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -1811,7 +1818,8 @@ exports[`Compact renders correctly 1`] = `
             }
             value="77"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-4"
             onMouseDown={[Function]}
             style={
               Object {
@@ -1826,7 +1834,7 @@ exports[`Compact renders correctly 1`] = `
             }
           >
             b
-          </span>
+          </label>
         </div>
       </div>
     </div>
@@ -3517,6 +3525,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-5"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -3537,7 +3546,8 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
             value="#22194D"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-5"
             onMouseDown={[Function]}
             style={
               Object {
@@ -3546,7 +3556,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
           >
             hex
-          </span>
+          </label>
         </div>
         <div
           style={
@@ -3561,6 +3571,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-6"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -3581,7 +3592,8 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
             value="34"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-6"
             onMouseDown={[Function]}
             style={
               Object {
@@ -3596,7 +3608,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
           >
             r
-          </span>
+          </label>
         </div>
         <div
           style={
@@ -3611,6 +3623,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-7"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -3631,7 +3644,8 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
             value="25"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-7"
             onMouseDown={[Function]}
             style={
               Object {
@@ -3646,7 +3660,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
           >
             g
-          </span>
+          </label>
         </div>
         <div
           style={
@@ -3661,6 +3675,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
           }
         >
           <input
+            id="rc-editable-input-8"
             onBlur={[Function]}
             onChange={[Function]}
             onKeyDown={[Function]}
@@ -3681,7 +3696,8 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
             value="77"
           />
-          <span
+          <label
+            htmlFor="rc-editable-input-8"
             onMouseDown={[Function]}
             style={
               Object {
@@ -3696,7 +3712,7 @@ exports[`Compact with onSwatchHover renders correctly 1`] = `
             }
           >
             b
-          </span>
+          </label>
         </div>
       </div>
     </div>
@@ -3787,6 +3803,7 @@ exports[`CompactFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-17"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -3807,7 +3824,8 @@ exports[`CompactFields renders correctly 1`] = `
       }
       value="#FF0000"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-17"
       onMouseDown={[Function]}
       style={
         Object {
@@ -3816,7 +3834,7 @@ exports[`CompactFields renders correctly 1`] = `
       }
     >
       hex
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -3831,6 +3849,7 @@ exports[`CompactFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-18"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -3851,7 +3870,8 @@ exports[`CompactFields renders correctly 1`] = `
       }
       value="255"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-18"
       onMouseDown={[Function]}
       style={
         Object {
@@ -3866,7 +3886,7 @@ exports[`CompactFields renders correctly 1`] = `
       }
     >
       r
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -3881,6 +3901,7 @@ exports[`CompactFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-19"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -3901,7 +3922,8 @@ exports[`CompactFields renders correctly 1`] = `
       }
       value="0"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-19"
       onMouseDown={[Function]}
       style={
         Object {
@@ -3916,7 +3938,7 @@ exports[`CompactFields renders correctly 1`] = `
       }
     >
       g
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -3931,6 +3953,7 @@ exports[`CompactFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-20"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -3951,7 +3974,8 @@ exports[`CompactFields renders correctly 1`] = `
       }
       value="0"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-20"
       onMouseDown={[Function]}
       style={
         Object {
@@ -3966,7 +3990,7 @@ exports[`CompactFields renders correctly 1`] = `
       }
     >
       b
-    </span>
+    </label>
   </div>
 </div>
 `;

--- a/src/components/material/__snapshots__/spec.js.snap
+++ b/src/components/material/__snapshots__/spec.js.snap
@@ -57,6 +57,7 @@ exports[`Material renders correctly 1`] = `
         }
       >
         <input
+          id="rc-editable-input-1"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -77,7 +78,8 @@ exports[`Material renders correctly 1`] = `
           }
           value="#22194D"
         />
-        <span
+        <label
+          htmlFor="rc-editable-input-1"
           onMouseDown={[Function]}
           style={
             Object {
@@ -91,7 +93,7 @@ exports[`Material renders correctly 1`] = `
           }
         >
           hex
-        </span>
+        </label>
       </div>
       <div
         className="flexbox-fix"
@@ -123,6 +125,7 @@ exports[`Material renders correctly 1`] = `
             }
           >
             <input
+              id="rc-editable-input-2"
               onBlur={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -143,7 +146,8 @@ exports[`Material renders correctly 1`] = `
               }
               value="34"
             />
-            <span
+            <label
+              htmlFor="rc-editable-input-2"
               onMouseDown={[Function]}
               style={
                 Object {
@@ -157,7 +161,7 @@ exports[`Material renders correctly 1`] = `
               }
             >
               r
-            </span>
+            </label>
           </div>
         </div>
         <div
@@ -180,6 +184,7 @@ exports[`Material renders correctly 1`] = `
             }
           >
             <input
+              id="rc-editable-input-3"
               onBlur={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -200,7 +205,8 @@ exports[`Material renders correctly 1`] = `
               }
               value="25"
             />
-            <span
+            <label
+              htmlFor="rc-editable-input-3"
               onMouseDown={[Function]}
               style={
                 Object {
@@ -214,7 +220,7 @@ exports[`Material renders correctly 1`] = `
               }
             >
               g
-            </span>
+            </label>
           </div>
         </div>
         <div
@@ -237,6 +243,7 @@ exports[`Material renders correctly 1`] = `
             }
           >
             <input
+              id="rc-editable-input-4"
               onBlur={[Function]}
               onChange={[Function]}
               onKeyDown={[Function]}
@@ -257,7 +264,8 @@ exports[`Material renders correctly 1`] = `
               }
               value="77"
             />
-            <span
+            <label
+              htmlFor="rc-editable-input-4"
               onMouseDown={[Function]}
               style={
                 Object {
@@ -271,7 +279,7 @@ exports[`Material renders correctly 1`] = `
               }
             >
               b
-            </span>
+            </label>
           </div>
         </div>
       </div>

--- a/src/components/photoshop/__snapshots__/spec.js.snap
+++ b/src/components/photoshop/__snapshots__/spec.js.snap
@@ -481,6 +481,7 @@ exports[`Photoshop renders correctly 1`] = `
               }
             >
               <input
+                id="rc-editable-input-1"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}
@@ -505,7 +506,8 @@ exports[`Photoshop renders correctly 1`] = `
                 }
                 value="250"
               />
-              <span
+              <label
+                htmlFor="rc-editable-input-1"
                 onMouseDown={[Function]}
                 style={
                   Object {
@@ -520,7 +522,7 @@ exports[`Photoshop renders correctly 1`] = `
                 }
               >
                 h
-              </span>
+              </label>
             </div>
             <div
               style={
@@ -530,6 +532,7 @@ exports[`Photoshop renders correctly 1`] = `
               }
             >
               <input
+                id="rc-editable-input-2"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}
@@ -554,7 +557,8 @@ exports[`Photoshop renders correctly 1`] = `
                 }
                 value="67"
               />
-              <span
+              <label
+                htmlFor="rc-editable-input-2"
                 onMouseDown={[Function]}
                 style={
                   Object {
@@ -569,7 +573,7 @@ exports[`Photoshop renders correctly 1`] = `
                 }
               >
                 s
-              </span>
+              </label>
             </div>
             <div
               style={
@@ -579,6 +583,7 @@ exports[`Photoshop renders correctly 1`] = `
               }
             >
               <input
+                id="rc-editable-input-3"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}
@@ -603,7 +608,8 @@ exports[`Photoshop renders correctly 1`] = `
                 }
                 value="30"
               />
-              <span
+              <label
+                htmlFor="rc-editable-input-3"
                 onMouseDown={[Function]}
                 style={
                   Object {
@@ -618,7 +624,7 @@ exports[`Photoshop renders correctly 1`] = `
                 }
               >
                 v
-              </span>
+              </label>
             </div>
             <div
               style={
@@ -635,6 +641,7 @@ exports[`Photoshop renders correctly 1`] = `
               }
             >
               <input
+                id="rc-editable-input-4"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}
@@ -659,7 +666,8 @@ exports[`Photoshop renders correctly 1`] = `
                 }
                 value="34"
               />
-              <span
+              <label
+                htmlFor="rc-editable-input-4"
                 onMouseDown={[Function]}
                 style={
                   Object {
@@ -674,7 +682,7 @@ exports[`Photoshop renders correctly 1`] = `
                 }
               >
                 r
-              </span>
+              </label>
             </div>
             <div
               style={
@@ -684,6 +692,7 @@ exports[`Photoshop renders correctly 1`] = `
               }
             >
               <input
+                id="rc-editable-input-5"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}
@@ -708,7 +717,8 @@ exports[`Photoshop renders correctly 1`] = `
                 }
                 value="25"
               />
-              <span
+              <label
+                htmlFor="rc-editable-input-5"
                 onMouseDown={[Function]}
                 style={
                   Object {
@@ -723,7 +733,7 @@ exports[`Photoshop renders correctly 1`] = `
                 }
               >
                 g
-              </span>
+              </label>
             </div>
             <div
               style={
@@ -733,6 +743,7 @@ exports[`Photoshop renders correctly 1`] = `
               }
             >
               <input
+                id="rc-editable-input-6"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}
@@ -757,7 +768,8 @@ exports[`Photoshop renders correctly 1`] = `
                 }
                 value="77"
               />
-              <span
+              <label
+                htmlFor="rc-editable-input-6"
                 onMouseDown={[Function]}
                 style={
                   Object {
@@ -772,7 +784,7 @@ exports[`Photoshop renders correctly 1`] = `
                 }
               >
                 b
-              </span>
+              </label>
             </div>
             <div
               style={
@@ -789,6 +801,7 @@ exports[`Photoshop renders correctly 1`] = `
               }
             >
               <input
+                id="rc-editable-input-7"
                 onBlur={[Function]}
                 onChange={[Function]}
                 onKeyDown={[Function]}
@@ -812,7 +825,8 @@ exports[`Photoshop renders correctly 1`] = `
                 }
                 value="22194D"
               />
-              <span
+              <label
+                htmlFor="rc-editable-input-7"
                 onMouseDown={[Function]}
                 style={
                   Object {
@@ -828,7 +842,7 @@ exports[`Photoshop renders correctly 1`] = `
                 }
               >
                 #
-              </span>
+              </label>
             </div>
             <div
               style={
@@ -932,6 +946,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-15"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -956,7 +971,8 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
       value="0"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-15"
       onMouseDown={[Function]}
       style={
         Object {
@@ -971,7 +987,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
     >
       h
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -981,6 +997,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-16"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -1005,7 +1022,8 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
       value="100"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-16"
       onMouseDown={[Function]}
       style={
         Object {
@@ -1020,7 +1038,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
     >
       s
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -1030,6 +1048,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-17"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -1054,7 +1073,8 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
       value="100"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-17"
       onMouseDown={[Function]}
       style={
         Object {
@@ -1069,7 +1089,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
     >
       v
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -1086,6 +1106,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-18"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -1110,7 +1131,8 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
       value="255"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-18"
       onMouseDown={[Function]}
       style={
         Object {
@@ -1125,7 +1147,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
     >
       r
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -1135,6 +1157,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-19"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -1159,7 +1182,8 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
       value="0"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-19"
       onMouseDown={[Function]}
       style={
         Object {
@@ -1174,7 +1198,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
     >
       g
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -1184,6 +1208,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-20"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -1208,7 +1233,8 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
       value="0"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-20"
       onMouseDown={[Function]}
       style={
         Object {
@@ -1223,7 +1249,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
     >
       b
-    </span>
+    </label>
   </div>
   <div
     style={
@@ -1240,6 +1266,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
     }
   >
     <input
+      id="rc-editable-input-21"
       onBlur={[Function]}
       onChange={[Function]}
       onKeyDown={[Function]}
@@ -1263,7 +1290,8 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
       value="FF0000"
     />
-    <span
+    <label
+      htmlFor="rc-editable-input-21"
       onMouseDown={[Function]}
       style={
         Object {
@@ -1279,7 +1307,7 @@ exports[`PhotoshopFields renders correctly 1`] = `
       }
     >
       #
-    </span>
+    </label>
   </div>
   <div
     style={

--- a/src/components/sketch/__snapshots__/spec.js.snap
+++ b/src/components/sketch/__snapshots__/spec.js.snap
@@ -497,6 +497,7 @@ exports[`Sketch renders correctly 1`] = `
         }
       >
         <input
+          id="rc-editable-input-1"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -517,7 +518,8 @@ exports[`Sketch renders correctly 1`] = `
           }
           value="22194D"
         />
-        <span
+        <label
+          htmlFor="rc-editable-input-1"
           onMouseDown={[Function]}
           style={
             Object {
@@ -532,7 +534,7 @@ exports[`Sketch renders correctly 1`] = `
           }
         >
           hex
-        </span>
+        </label>
       </div>
     </div>
     <div
@@ -555,6 +557,7 @@ exports[`Sketch renders correctly 1`] = `
         }
       >
         <input
+          id="rc-editable-input-2"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -575,7 +578,8 @@ exports[`Sketch renders correctly 1`] = `
           }
           value="34"
         />
-        <span
+        <label
+          htmlFor="rc-editable-input-2"
           onMouseDown={[Function]}
           style={
             Object {
@@ -591,7 +595,7 @@ exports[`Sketch renders correctly 1`] = `
           }
         >
           r
-        </span>
+        </label>
       </div>
     </div>
     <div
@@ -614,6 +618,7 @@ exports[`Sketch renders correctly 1`] = `
         }
       >
         <input
+          id="rc-editable-input-3"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -634,7 +639,8 @@ exports[`Sketch renders correctly 1`] = `
           }
           value="25"
         />
-        <span
+        <label
+          htmlFor="rc-editable-input-3"
           onMouseDown={[Function]}
           style={
             Object {
@@ -650,7 +656,7 @@ exports[`Sketch renders correctly 1`] = `
           }
         >
           g
-        </span>
+        </label>
       </div>
     </div>
     <div
@@ -673,6 +679,7 @@ exports[`Sketch renders correctly 1`] = `
         }
       >
         <input
+          id="rc-editable-input-4"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -693,7 +700,8 @@ exports[`Sketch renders correctly 1`] = `
           }
           value="77"
         />
-        <span
+        <label
+          htmlFor="rc-editable-input-4"
           onMouseDown={[Function]}
           style={
             Object {
@@ -709,7 +717,7 @@ exports[`Sketch renders correctly 1`] = `
           }
         >
           b
-        </span>
+        </label>
       </div>
     </div>
     <div
@@ -732,6 +740,7 @@ exports[`Sketch renders correctly 1`] = `
         }
       >
         <input
+          id="rc-editable-input-5"
           onBlur={[Function]}
           onChange={[Function]}
           onKeyDown={[Function]}
@@ -752,7 +761,8 @@ exports[`Sketch renders correctly 1`] = `
           }
           value="100"
         />
-        <span
+        <label
+          htmlFor="rc-editable-input-5"
           onMouseDown={[Function]}
           style={
             Object {
@@ -768,7 +778,7 @@ exports[`Sketch renders correctly 1`] = `
           }
         >
           a
-        </span>
+        </label>
       </div>
     </div>
   </div>
@@ -1433,6 +1443,7 @@ exports[`SketchFields renders correctly 1`] = `
       }
     >
       <input
+        id="rc-editable-input-21"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -1453,7 +1464,8 @@ exports[`SketchFields renders correctly 1`] = `
         }
         value="FF0000"
       />
-      <span
+      <label
+        htmlFor="rc-editable-input-21"
         onMouseDown={[Function]}
         style={
           Object {
@@ -1468,7 +1480,7 @@ exports[`SketchFields renders correctly 1`] = `
         }
       >
         hex
-      </span>
+      </label>
     </div>
   </div>
   <div
@@ -1491,6 +1503,7 @@ exports[`SketchFields renders correctly 1`] = `
       }
     >
       <input
+        id="rc-editable-input-22"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -1511,7 +1524,8 @@ exports[`SketchFields renders correctly 1`] = `
         }
         value="255"
       />
-      <span
+      <label
+        htmlFor="rc-editable-input-22"
         onMouseDown={[Function]}
         style={
           Object {
@@ -1527,7 +1541,7 @@ exports[`SketchFields renders correctly 1`] = `
         }
       >
         r
-      </span>
+      </label>
     </div>
   </div>
   <div
@@ -1550,6 +1564,7 @@ exports[`SketchFields renders correctly 1`] = `
       }
     >
       <input
+        id="rc-editable-input-23"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -1570,7 +1585,8 @@ exports[`SketchFields renders correctly 1`] = `
         }
         value="0"
       />
-      <span
+      <label
+        htmlFor="rc-editable-input-23"
         onMouseDown={[Function]}
         style={
           Object {
@@ -1586,7 +1602,7 @@ exports[`SketchFields renders correctly 1`] = `
         }
       >
         g
-      </span>
+      </label>
     </div>
   </div>
   <div
@@ -1609,6 +1625,7 @@ exports[`SketchFields renders correctly 1`] = `
       }
     >
       <input
+        id="rc-editable-input-24"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -1629,7 +1646,8 @@ exports[`SketchFields renders correctly 1`] = `
         }
         value="0"
       />
-      <span
+      <label
+        htmlFor="rc-editable-input-24"
         onMouseDown={[Function]}
         style={
           Object {
@@ -1645,7 +1663,7 @@ exports[`SketchFields renders correctly 1`] = `
         }
       >
         b
-      </span>
+      </label>
     </div>
   </div>
   <div
@@ -1668,6 +1686,7 @@ exports[`SketchFields renders correctly 1`] = `
       }
     >
       <input
+        id="rc-editable-input-25"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -1688,7 +1707,8 @@ exports[`SketchFields renders correctly 1`] = `
         }
         value="100"
       />
-      <span
+      <label
+        htmlFor="rc-editable-input-25"
         onMouseDown={[Function]}
         style={
           Object {
@@ -1704,7 +1724,7 @@ exports[`SketchFields renders correctly 1`] = `
         }
       >
         a
-      </span>
+      </label>
     </div>
   </div>
 </div>

--- a/src/components/twitter/__snapshots__/spec.js.snap
+++ b/src/components/twitter/__snapshots__/spec.js.snap
@@ -365,6 +365,7 @@ exports[`Twitter \`triangle="hide"\` 1`] = `
       }
     >
       <input
+        id="rc-editable-input-3"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -774,6 +775,7 @@ exports[`Twitter \`triangle="top-right"\` 1`] = `
       }
     >
       <input
+        id="rc-editable-input-4"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}
@@ -1183,6 +1185,7 @@ exports[`Twitter renders correctly 1`] = `
       }
     >
       <input
+        id="rc-editable-input-1"
         onBlur={[Function]}
         onChange={[Function]}
         onKeyDown={[Function]}


### PR DESCRIPTION
**Issue**

aXe accessibility tests fail due to error, "Form elements must have labels". This can be seen on any component using EditableInput.

**This PR**:

- Generates a unique identifier for the input field of `rc-editable-input-n`
- Changes `span` to `label`
- Associates the label to the input field

