### PR TITLE
fix: add missing peer dependnecy react

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "reactcss": "^1.2.0",
     "tinycolor2": "^1.4.1"
   },
+  "peerDependencies": {
+    "react": "*"
+  },
   "devDependencies": {
     "@case/eslint-config": "^0.3.1",
     "@storybook/addon-centered": "^3.2.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`react-color` is trying to use `react` without declaring it as a peer dependency

**How did you fix it?**

Added `react` to peer dependencies