### PR TITLE
Use lodash-es in esm and lodash in commonjs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,16 +1,6 @@
 {
-  "env": {
-    "test": {
-      "presets": ["es2015", "stage-0", "react"]
-    }
-  },
   "presets": [
-    [
-      "es2015",
-      {
-        "modules": false
-      }
-    ],
+    "es2015",
     "stage-0",
     "react"
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ node_modules
 package-lock.json
 
 lib
+es
+.babelrc_backup

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 package-lock.json
 
 lib
-es

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "2.18.1",
   "description": "A Collection of Color Pickers from Sketch, Photoshop, Chrome & more",
   "main": "lib/index.js",
-  "module": "es/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/casesandberg/react-color.git"
@@ -17,11 +16,9 @@
     "test": "npm run jest && npm run eslint",
     "jest": "jest",
     "eslint": "eslint src/**/*.js",
-    "lib": "npm run clean-lib && babel --no-babelrc --presets=es2015,stage-0,react src -d lib",
-    "es": "npm run clean-es && babel src -d es",
-    "clean-lib": "rm -rf lib && mkdir lib",
-    "clean-es": "rm -rf es && mkdir es",
-    "prepublish": "npm run lib && npm run es",
+    "lib": "npm run clean && babel src -d lib",
+    "clean": "rm -rf lib && mkdir lib",
+    "prepublish": "npm run lib",
     "docs": "npm run docs-server",
     "docs-server": "node ./scripts/docs-server",
     "docs-dist": "node ./scripts/docs-dist",
@@ -44,7 +41,7 @@
   ],
   "dependencies": {
     "@icons/material": "^0.2.4",
-    "lodash-es": "^4.17.15",
+    "lodash": "^4.17.11",
     "material-colors": "^1.2.1",
     "prop-types": "^15.5.10",
     "reactcss": "^1.2.0",
@@ -61,7 +58,7 @@
     "@storybook/react": "^3.2.4",
     "babel-cli": "^6.8.0",
     "babel-core": "^6.10.4",
-    "babel-jest": "^20.0.3",
+    "babel-jest": "^16.0.0",
     "babel-loader": "^6.2.1",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
@@ -77,7 +74,7 @@
     "html-loader": "^0.3.0",
     "html-webpack-plugin": "^3.2.0",
     "i": "^0.3.5",
-    "jest": "^20.0.4",
+    "jest": "^16.0.2",
     "jest-cli": "^20.0.4",
     "jsx-loader": "^0.13.2",
     "mocha": "^2.4.5",
@@ -100,15 +97,11 @@
     "webpack-dev-server": "^1.10.1"
   },
   "files": [
-    "lib",
-    "es"
+    "lib"
   ],
   "jest": {
     "rootDir": "src",
-    "testRegex": "spec.js$",
-    "transformIgnorePatterns": [
-      "/!node_modules\\/lodash-es/"
-    ]
+    "testRegex": "spec.js$"
   },
   "eslintConfig": {
     "extends": "@case",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.18.1",
   "description": "A Collection of Color Pickers from Sketch, Photoshop, Chrome & more",
   "main": "lib/index.js",
+  "module": "es/index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/casesandberg/react-color.git"
@@ -16,9 +17,11 @@
     "test": "npm run jest && npm run eslint",
     "jest": "jest",
     "eslint": "eslint src/**/*.js",
-    "lib": "npm run clean && babel src -d lib",
-    "clean": "rm -rf lib && mkdir lib",
-    "prepublish": "npm run lib",
+    "lib": "npm run clean-lib && babel src -d lib",
+    "es": "npm run clean-es && node scripts/use-module-babelrc.js && babel src -d es && node scripts/restore-original-babelrc.js",
+    "clean-lib": "rm -rf lib && mkdir lib",
+    "clean-es": "rm -rf es && mkdir es",
+    "prepublish": "npm run lib && npm run es",
     "docs": "npm run docs-server",
     "docs-server": "node ./scripts/docs-server",
     "docs-dist": "node ./scripts/docs-dist",
@@ -41,7 +44,8 @@
   ],
   "dependencies": {
     "@icons/material": "^0.2.4",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
+    "lodash-es": "^4.17.15",
     "material-colors": "^1.2.1",
     "prop-types": "^15.5.10",
     "reactcss": "^1.2.0",
@@ -58,8 +62,9 @@
     "@storybook/react": "^3.2.4",
     "babel-cli": "^6.8.0",
     "babel-core": "^6.10.4",
-    "babel-jest": "^16.0.0",
+    "babel-jest": "^20.0.3",
     "babel-loader": "^6.2.1",
+    "babel-plugin-transform-rename-import": "^2.3.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
@@ -74,7 +79,7 @@
     "html-loader": "^0.3.0",
     "html-webpack-plugin": "^3.2.0",
     "i": "^0.3.5",
-    "jest": "^16.0.2",
+    "jest": "^20.0.4",
     "jest-cli": "^20.0.4",
     "jsx-loader": "^0.13.2",
     "mocha": "^2.4.5",
@@ -97,7 +102,8 @@
     "webpack-dev-server": "^1.10.1"
   },
   "files": [
-    "lib"
+    "lib",
+    "es"
   ],
   "jest": {
     "rootDir": "src",

--- a/scripts/restore-original-babelrc.js
+++ b/scripts/restore-original-babelrc.js
@@ -1,0 +1,11 @@
+const fs = require('fs')
+const path = require('path')
+
+const babelRCBackup = fs
+  .readFileSync(path.join(__dirname, '../.babelrc_backup'))
+  .toString()
+
+fs.writeFileSync(
+  path.join(__dirname, '../.babelrc'),
+  babelRCBackup
+)

--- a/scripts/use-module-babelrc.js
+++ b/scripts/use-module-babelrc.js
@@ -1,0 +1,27 @@
+const fs = require('fs')
+const path = require('path')
+
+const originalBabelRC = fs
+  .readFileSync(path.join(__dirname, '../.babelrc'))
+  .toString()
+
+fs.writeFileSync(path.join(__dirname, '../.babelrc_backup'), originalBabelRC)
+
+const esBabelRC = {
+  presets: [
+    ['es2015', { modules: false }],
+    'stage-0',
+    'react',
+  ],
+  plugins: [
+    [
+      'transform-rename-import',
+      {
+        'original': 'lodash',
+        'replacement': 'lodash-es',
+      },
+    ],
+  ],
+}
+
+fs.writeFileSync(path.join(__dirname, '../.babelrc'), JSON.stringify(esBabelRC))

--- a/src/components/block/Block.js
+++ b/src/components/block/Block.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Checkboard } from '../common'

--- a/src/components/block/BlockSwatches.js
+++ b/src/components/block/BlockSwatches.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import reactCSS from 'reactcss'
-import { map } from 'lodash-es'
+import map from 'lodash/map'
 
 import { Swatch } from '../common'
 

--- a/src/components/chrome/Chrome.js
+++ b/src/components/chrome/Chrome.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Saturation, Hue, Alpha, Checkboard } from '../common'
 import ChromeFields from './ChromeFields'

--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -3,7 +3,7 @@
 import React from 'react'
 import reactCSS from 'reactcss'
 import color from '../../helpers/color'
-import { isUndefined } from 'lodash-es'
+import isUndefined from 'lodash/isUndefined'
 
 import { EditableInput } from '../common'
 import UnfoldMoreHorizontalIcon from '@icons/material/UnfoldMoreHorizontalIcon'

--- a/src/components/circle/Circle.js
+++ b/src/components/circle/Circle.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { map, merge } from 'lodash-es'
+import map from 'lodash/map'
+import merge from 'lodash/merge'
 import * as material from 'material-colors'
 
 import { ColorWrap } from '../common'

--- a/src/components/common/ColorWrap.js
+++ b/src/components/common/ColorWrap.js
@@ -1,5 +1,5 @@
 import React, { Component, PureComponent } from 'react'
-import { debounce } from 'lodash-es'
+import debounce from 'lodash/debounce'
 import color from '../../helpers/color'
 
 export const ColorWrap = (Picker) => {

--- a/src/components/common/Raised.js
+++ b/src/components/common/Raised.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 
 export const Raised = ({ zDepth, radius, background, children,
   styles: passedStyles = {} }) => {

--- a/src/components/common/Saturation.js
+++ b/src/components/common/Saturation.js
@@ -1,6 +1,6 @@
 import React, { Component, PureComponent } from 'react'
 import reactCSS from 'reactcss'
-import { throttle } from 'lodash-es'
+import throttle from 'lodash/throttle'
 import * as saturation from '../../helpers/saturation'
 
 export class Saturation extends (PureComponent || Component) {

--- a/src/components/compact/Compact.js
+++ b/src/components/compact/Compact.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { map, merge } from 'lodash-es'
+import map from 'lodash/map'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, Raised } from '../common'

--- a/src/components/github/Github.js
+++ b/src/components/github/Github.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { map, merge } from 'lodash-es'
+import map from 'lodash/map'
+import merge from 'lodash/merge'
 
 import { ColorWrap } from '../common'
 import GithubSwatch from './GithubSwatch'

--- a/src/components/hue/Hue.js
+++ b/src/components/hue/Hue.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Hue } from '../common'
 import HuePointer from './HuePointer'

--- a/src/components/material/Material.js
+++ b/src/components/material/Material.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Raised } from '../common'

--- a/src/components/photoshop/Photoshop.js
+++ b/src/components/photoshop/Photoshop.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Saturation, Hue } from '../common'
 import PhotoshopFields from './PhotoshopFields'

--- a/src/components/sketch/Sketch.js
+++ b/src/components/sketch/Sketch.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Saturation, Hue, Alpha, Checkboard } from '../common'
 import SketchFields from './SketchFields'

--- a/src/components/slider/Slider.js
+++ b/src/components/slider/Slider.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { merge } from 'lodash-es'
+import merge from 'lodash/merge'
 
 import { ColorWrap, Hue } from '../common'
 import SliderSwatches from './SliderSwatches'

--- a/src/components/swatches/Swatches.js
+++ b/src/components/swatches/Swatches.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { map, merge } from 'lodash-es'
+import map from 'lodash/map'
+import merge from 'lodash/merge'
 import * as material from 'material-colors'
 
 import { ColorWrap, Raised } from '../common'

--- a/src/components/swatches/SwatchesGroup.js
+++ b/src/components/swatches/SwatchesGroup.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import reactCSS from 'reactcss'
-import { map } from 'lodash-es'
+import map from 'lodash/map'
 
 import SwatchesColor from './SwatchesColor'
 

--- a/src/components/twitter/Twitter.js
+++ b/src/components/twitter/Twitter.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import reactCSS from 'reactcss'
-import { map, merge } from 'lodash-es'
+import map from 'lodash/map'
+import merge from 'lodash/merge'
 import color from '../../helpers/color'
 
 import { ColorWrap, EditableInput, Swatch } from '../common'

--- a/src/helpers/color.js
+++ b/src/helpers/color.js
@@ -1,4 +1,4 @@
-import { each } from 'lodash-es'
+import each from 'lodash/each'
 import tinycolor from 'tinycolor2'
 
 export const simpleCheckForValidColor = (data) => {


### PR DESCRIPTION
Inspired from https://github.com/jquense/yup/pull/756.
lodash-es does not work in commonjs builds. So, we need lodash on commonjs and lodash-es on es module.
The code will be using lodash but on building es dist, we replace lodash with lodash-es using https://www.npmjs.com/package/babel-plugin-transform-rename-import.