### PR TITLE
Bump lodash to 4.17.20 to address Prototype Pollution vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   ],
   "dependencies": {
     "@icons/material": "^0.2.4",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.20",
     "lodash-es": "^4.17.15",
     "material-colors": "^1.2.1",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
This is to address https://www.npmjs.com/advisories/1523    

