### PR TITLE
Fix/#754

### DIFF
--- a/src/components/common/ColorWrap.js
+++ b/src/components/common/ColorWrap.js
@@ -16,9 +16,9 @@ export const ColorWrap = (Picker) => {
       }, 100)
     }
 
-    static getDerivedStateFromProps(nextProps, state) {
-      return {
-        ...color.toState(nextProps.color, state.oldHue),
+    componentDidUpdate(prevProps) {
+      if (prevProps.color !== this.props.color) {
+        this.setState({ ...color.toState(this.props.color, state.oldHue) });
       }
     }
 


### PR DESCRIPTION
- Made changes to run CustomPicker aka  ColorWrap HoC in all version of React. 
- Replaced `getDerivedStateFromProps` with `componentDidUpdate` and put a check on colour input props before updating color state

- [x] Ran `npm run test` and verified all test cases are getting passed 
- [x]  Ran `npm run eslint` and there was not any es-lint errors
- [x] Verified these changes in `custom-picker` example with both the latest(6.12.0) and old version (15.6.1) of react
