### PR TITLE
Add GitHub Actions workflow to publish package on release

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
This GitHub Actions workflow will automatically release the package to npm when a release is reated on GitHub (as long as tests pass). This will prevent issues like #764 coming up.

Note: before this will work, the `npm_token` secret must be configured with a token that has publish permissions for this package on npm. See [Building and testing Node.js documentation](https://docs.github.com/en/free-pro-team@latest/actions/guides/building-and-testing-nodejs#example-using-a-private-registry-and-creating-the-npmrc-file) on the GitHub docs for more info.