### PR TITLE
Remove unreferenced exports

### DIFF
--- a/src/helpers/color.js
+++ b/src/helpers/color.js
@@ -77,4 +77,4 @@ export const isvalidColorString = (string, type) => {
   return tinycolor(`${ type } (${ stringWithoutDegree })`)._ok
 }
 
-export default exports
+


### PR DESCRIPTION
`export default exports` is causing **Uncaught ReferenceError: exports is not defined**

It used to be `exports.default = exports;` And the line is not required in es6 format.