### PR TITLE
Add preserving alpha in chrome while changing other values

### DIFF
--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -55,6 +55,7 @@ export class ChromeFields extends React.Component {
         r: data.r || this.props.rgb.r,
         g: data.g || this.props.rgb.g,
         b: data.b || this.props.rgb.b,
+        a: this.props.rgb.a,
         source: 'rgb',
       }, e)
     } else if (data.a) {
@@ -87,6 +88,7 @@ export class ChromeFields extends React.Component {
         h: data.h || this.props.hsl.h,
         s: Number(!isUndefined(data.s) ? data.s : this.props.hsl.s),
         l: Number(!isUndefined(data.l) ? data.l : this.props.hsl.l),
+        a: this.props.rgb.a,
         source: 'hsl',
       }, e)
     }


### PR DESCRIPTION
This is fix of a bug in chrome picker.

Case.
Change chrome picker mode to rgba or hsla, type "0.5" to alpha input. Change any other value: r, g, b, h, s or l.

Expected Result. Alpha value preserves as "0.5".
Actual result. Alpha value becomes "1".