### PR TITLE
Drop @icons/material dep by vendoring two icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "popup"
   ],
   "dependencies": {
-    "@icons/material": "^0.2.4",
     "lodash": "^4.17.15",
     "lodash-es": "^4.17.15",
     "material-colors": "^1.2.1",

--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -6,7 +6,7 @@ import * as color from '../../helpers/color'
 import isUndefined from 'lodash/isUndefined'
 
 import { EditableInput } from '../common'
-import UnfoldMoreHorizontalIcon from '@icons/material/UnfoldMoreHorizontalIcon'
+import UnfoldMoreHorizontalIcon from './UnfoldMoreHorizontalIcon'
 
 export class ChromeFields extends React.Component {
   constructor(props) {

--- a/src/components/chrome/UnfoldMoreHorizontalIcon.js
+++ b/src/components/chrome/UnfoldMoreHorizontalIcon.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+const DEFAULT_SIZE = 24
+
+export default ({
+  fill = 'currentColor',
+  width = DEFAULT_SIZE,
+  height = DEFAULT_SIZE,
+  style = {},
+  ...props
+}) => (
+  <svg
+    viewBox={ `0 0 ${ DEFAULT_SIZE } ${ DEFAULT_SIZE }` }
+    style={{ fill, width, height, ...style }}
+    { ...props }
+  >
+    <path d="M12,18.17L8.83,15L7.42,16.41L12,21L16.59,16.41L15.17,15M12,5.83L15.17,9L16.58,7.59L12,3L7.41,7.59L8.83,9L12,5.83Z" />
+  </svg>
+)

--- a/src/components/swatches/CheckIcon.js
+++ b/src/components/swatches/CheckIcon.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+const DEFAULT_SIZE = 24
+
+export default ({
+  fill = 'currentColor',
+  width = DEFAULT_SIZE,
+  height = DEFAULT_SIZE,
+  style = {},
+  ...props
+}) => (
+  <svg
+    viewBox={ `0 0 ${ DEFAULT_SIZE } ${ DEFAULT_SIZE }` }
+    style={{ fill, width, height, ...style }}
+    { ...props }
+  >
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z" />
+  </svg>
+)

--- a/src/components/swatches/SwatchesColor.js
+++ b/src/components/swatches/SwatchesColor.js
@@ -3,7 +3,7 @@ import reactCSS from 'reactcss'
 import * as colorUtils from '../../helpers/color'
 
 import { Swatch } from '../common'
-import CheckIcon from '@icons/material/CheckIcon'
+import CheckIcon from './CheckIcon'
 
 export const SwatchesColor = ({ color, onClick = () => {}, onSwatchHover, first,
   last, active }) => {


### PR DESCRIPTION
This reduces node_modules size by ~19MB for module consumers