### PR TITLE
fix for #754 prevent ColorWrap to reset own state

### DIFF
--- a/src/components/common/ColorWrap.js
+++ b/src/components/common/ColorWrap.js
@@ -8,7 +8,8 @@ export const ColorWrap = (Picker) => {
       super()
 
       this.state = {
-        ...color.toState(props.color, 0),
+        picker: { ...color.toState(props.color, 0) },
+        previousColorProp: props.color
       }
 
       this.debounce = debounce((fn, data, event) => {
@@ -17,16 +18,19 @@ export const ColorWrap = (Picker) => {
     }
 
     static getDerivedStateFromProps(nextProps, state) {
-      return {
-        ...color.toState(nextProps.color, state.oldHue),
+      if (nextProps.color !== state.previousColorProp) {
+        return {
+          picker: { ...color.toState(nextProps.color, state.picker.oldHue) },
+          previousColorProp: nextProps.color
+        }
       }
     }
 
     handleChange = (data, event) => {
       const isValidColor = color.simpleCheckForValidColor(data)
       if (isValidColor) {
-        const colors = color.toState(data, data.h || this.state.oldHue)
-        this.setState(colors)
+        const colors = color.toState(data, data.h || this.state.picker.oldHue)
+        this.setState({ picker: colors })
         this.props.onChangeComplete && this.debounce(this.props.onChangeComplete, colors, event)
         this.props.onChange && this.props.onChange(colors, event)
       }
@@ -35,7 +39,7 @@ export const ColorWrap = (Picker) => {
     handleSwatchHover = (data, event) => {
       const isValidColor = color.simpleCheckForValidColor(data)
       if (isValidColor) {
-        const colors = color.toState(data, data.h || this.state.oldHue)
+        const colors = color.toState(data, data.h || this.state.picker.oldHue)
         this.props.onSwatchHover && this.props.onSwatchHover(colors, event)
       }
     }
@@ -49,7 +53,7 @@ export const ColorWrap = (Picker) => {
       return (
         <Picker
           { ...this.props }
-          { ...this.state }
+          { ...this.state.picker }
           onChange={ this.handleChange }
           { ...optionalEvents }
         />


### PR DESCRIPTION
The issue is that ColorWrap HOC manages color state but at the same time accepts "color" prop which affects the state in getDerivedStateFromProps.
Because getDerivedStateFromProps is called every render, it always replaces state without actual checking if the color property was changed.
In the demo https://codesandbox.io/s/custom-picker-new-react-ur2z4 mentioned in #754 the component has initial value 'orange' - but it will overwrite component internal state every render.

I added a step to check if property was changed to prevent resetting internal state.

But to be honest I suggest to change the API of the component to avoid confusion.
In the example
```tsx
<MyPicker color="orange" onChangeComplete={handleColorChange} />
```
Color prop is always passed so it should never change it by its own.
If the intention is to provide initial value for the component, I think we should add 'defaultValue' property to indicate that it will be used only once.