### PR TITLE
eslint disable no underscore dangle warning for tiny color _ok

### DIFF
--- a/src/helpers/color.js
+++ b/src/helpers/color.js
@@ -74,5 +74,6 @@ export const red = {
 
 export const isvalidColorString = (string, type) => {
   const stringWithoutDegree = string.replace('°', '')
+  // eslint-disable-next-line no-underscore-dangle
   return tinycolor(`${ type } (${ stringWithoutDegree })`)._ok
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5863227/106303455-639dfc00-6217-11eb-8453-73a21c48bdd4.png)


I ran `test` on the master branch and saw this warning. The method is provided by third-party library, we should disable the warning for single line.. 