### PR TITLE
fix: Sketch Component keep the same props on server render and client render

### DIFF
--- a/src/components/sketch/Sketch.js
+++ b/src/components/sketch/Sketch.js
@@ -115,7 +115,9 @@ export const Sketch = ({ width, rgb, hex, hsv, hsl, onChange, onSwatchHover,
           </div>
         </div>
         <div style={ styles.color }>
-          <Checkboard />
+          <Checkboard
+            renderers={ renderers }
+          />
           <div style={ styles.activeColor } />
         </div>
       </div>


### PR DESCRIPTION
fix for #809 