### PR TITLE
Fixed using EditableInput in shadow DOM.

### DIFF
--- a/src/components/common/EditableInput.js
+++ b/src/components/common/EditableInput.js
@@ -31,7 +31,7 @@ export class EditableInput extends (PureComponent || Component) {
       this.props.value !== this.state.value &&
       (prevProps.value !== this.props.value || prevState.value !== this.state.value)
     ) {
-      if (this.input === document.activeElement) {
+      if (this.input === this.getInputRootNode().activeElement) {
         this.setState({ blurValue: String(this.props.value).toUpperCase() })
       } else {
         this.setState({ value: String(this.props.value).toUpperCase(), blurValue: !this.state.blurValue && String(this.props.value).toUpperCase() })
@@ -61,6 +61,10 @@ export class EditableInput extends (PureComponent || Component) {
 
   getArrowOffset() {
     return this.props.arrowOffset || DEFAULT_ARROW_OFFSET
+  }
+
+  getInputRootNode() {
+    return this.input.getRootNode ? this.input.getRootNode() : document;
   }
 
   handleKeyDown = (e) => {


### PR DESCRIPTION
When I tried to use `react-color` inside of a Shadow DOM then none of the text inputs worked. Digging down into the code I found this single line that was trying to access the active element from the top-level `document`.

In such a scenario:
```
<body>
  <custom-web-component>
    <AnyPickerWithEditableInput>
      <EditableInput/>
    <AnyPickerWithEditableInput/>
  <custom-web-component/>
<body/>
```
where the node of `custom-web-component` is the Shadow Root, `document.activeElement` was returning the Shadow Root node. Changing it to `getRootNode()` returns correct active elements and inputs start working.