### PR TITLE
Document how to change styles for Twitter-Picker

### DIFF
--- a/docs/documentation/03.04-individual.md
+++ b/docs/documentation/03.04-individual.md
@@ -71,3 +71,4 @@ Some pickers have specific APIs that are unique to themselves:
 * **colors** - Array of Strings, Color squares to display. Default `['#FF6900', '#FCB900', '#7BDCB5', '#00D084', '#8ED1FC', '#0693E3', '#ABB8C3', '#EB144C', '#F78DA7', '#9900EF']`
 * **triangle** - String, Either `hide`, `top-left` or `top-right`. Default `top-left`
 * **onSwatchHover** - An event handler for `onMouseOver` on the `<Swatch>`s within this component. Gives the args `(color, event)`
+* **styles** - [ReactCSS](https://github.com/casesandberg/reactcss) object to change [the default styles](https://github.com/casesandberg/react-color/blob/master/src/components/twitter/Twitter.js#L13-L79), eg `<TwitterPicker … styles={{ default: { input: { height: '30px' }}}} />`


### PR DESCRIPTION
This clarifies how to customise the styles.

It took me a while to figure out I need to add `default` to the styles hash. The styles example from https://casesandberg.github.io/react-color/#create-helpers `EditableInput` does not use the `default` hash. And the example at https://github.com/casesandberg/react-color/blob/master/docs/documentation/03.05-customStyles.md is not rendered at https://casesandberg.github.io/react-color/.