### PR TITLE
Add customStyles section to documentation

### DIFF
--- a/docs/documentation/index.js
+++ b/docs/documentation/index.js
@@ -9,6 +9,7 @@ module.exports = {
   '03.02-onChange': require('./03.02-onChange.md'),
   '03.03-onChangeComplete': require('./03.03-onChangeComplete.md'),
   '03.04-individual': require('./03.04-individual.md'),
+  '03.05-customStyles': require('./03.05-customStyles.md'),
   '04-create': require('./04-create.md'),
   '04.01-parent': require('./04.01-parent.md'),
   '04.02-helpers': require('./04.02-helpers.md'),


### PR DESCRIPTION
The page https://github.com/casesandberg/react-color/blob/master/docs/documentation/03.05-customStyles.md is ideal to explain how to customise styles but is missing from https://casesandberg.github.io/react-color/#api. 

Adding this will also resolve the need to document the styles props individually at https://github.com/casesandberg/react-color/pull/816