### PR TITLE
Allow color swatch to render correct on duplicate colors

### DIFF
--- a/src/components/block/BlockSwatches.js
+++ b/src/components/block/BlockSwatches.js
@@ -26,9 +26,9 @@ export const BlockSwatches = ({ colors, onClick, onSwatchHover }) => {
 
   return (
     <div style={ styles.swatches }>
-      { map(colors, c => (
+      { map(colors, (c, i) => (
         <Swatch
-          key={ c }
+          key={ i }
           color={ c }
           style={ styles.swatch }
           onClick={ onClick }

--- a/src/components/circle/Circle.js
+++ b/src/components/circle/Circle.js
@@ -26,9 +26,9 @@ export const Circle = ({ width, onChange, onSwatchHover, colors, hex, circleSize
 
   return (
     <div style={ styles.card } className={ `circle-picker ${ className }` }>
-      { map(colors, c => (
+      { map(colors, (c, i) => (
         <CircleSwatch
-          key={ c }
+          key={ i }
           color={ c }
           onClick={ handleChange }
           onSwatchHover={ onSwatchHover }

--- a/src/components/compact/Compact.js
+++ b/src/components/compact/Compact.js
@@ -44,9 +44,9 @@ export const Compact = ({ onChange, onSwatchHover, colors, hex, rgb,
     <Raised style={ styles.Compact } styles={ passedStyles }>
       <div style={ styles.compact } className={ `compact-picker ${ className }` }>
         <div>
-          { map(colors, (c) => (
+          { map(colors, (c, i) => (
             <CompactColor
-              key={ c }
+              key={ i }
               color={ c }
               active={ c.toLowerCase() === hex }
               onClick={ handleChange }

--- a/src/components/github/Github.js
+++ b/src/components/github/Github.js
@@ -99,10 +99,10 @@ export const Github = ({ width, colors, onChange, onSwatchHover, triangle,
     <div style={ styles.card } className={ `github-picker ${ className }` }>
       <div style={ styles.triangleShadow } />
       <div style={ styles.triangle } />
-      { map(colors, c => (
+      { map(colors, (c, i) => (
         <GithubSwatch
           color={ c }
-          key={ c }
+          key={ i }
           onClick={ handleChange }
           onSwatchHover={ onSwatchHover }
         />


### PR DESCRIPTION
When a user-provided colors list with duplicated colors is passed in
and is updated, the react renderer gets confused because the hex value
keys collide. Switching to indices to avoid this problem.

From the code, the Twitter picker already has this patched.