### PR TITLE
docs: include default chrome view picker props

### DIFF
--- a/docs/documentation/03.04-individual.md
+++ b/docs/documentation/03.04-individual.md
@@ -20,6 +20,7 @@ Some pickers have specific APIs that are unique to themselves:
 ### <Chrome />
 * **disableAlpha** - Bool, Remove alpha slider and options from picker. Default `false`
 * **renderers** - Object, Use { canvas: Canvas } with node canvas to do SSR
+* **defaultView** - String, Either `hex`, `rgb` or `hsl`. Default `hex`
 
 ### <Circle />
 * **width** - String, Pixel value for picker width. Default `252px`


### PR DESCRIPTION
Update documentation in order to include `defaultView` property. This will allow users to choose a default view for the Chrome Picker. It is an important property for developers looking for customize them components.

**Implemented at:** #665