### PR TITLE
fixed chromepicker alpha reverts to 1 on RGB change

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "git+https://github.com/casesandberg/react-color.git"
   },
-  "author": "case <case@casesandberg.com>",
+  "author": "case <case@casesandberg.com>", 
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/casesandberg/react-color/issues"

--- a/src/components/chrome/ChromeFields.js
+++ b/src/components/chrome/ChromeFields.js
@@ -43,6 +43,10 @@ export class ChromeFields extends React.Component {
       }
     }
   }
+  
+  checkValue = (value)=>{
+    return (!value || value<0)?false:true;
+  }
 
   handleChange = (data, e) => {
     if (data.hex) {
@@ -52,9 +56,10 @@ export class ChromeFields extends React.Component {
       }, e)
     } else if (data.r || data.g || data.b) {
       this.props.onChange({
-        r: data.r || this.props.rgb.r,
-        g: data.g || this.props.rgb.g,
-        b: data.b || this.props.rgb.b,
+        r: this.checkValue(data.r)? data.r : this.props.rgb.r,
+        g: this.checkValue(data.g)? data.g : this.props.rgb.g,
+        b: this.checkValue(data.b)? data.b : this.props.rgb.b,
+        a: this.checkValue(data.a)? data.a : this.props.rgb.a,
         source: 'rgb',
       }, e)
     } else if (data.a) {
@@ -87,6 +92,7 @@ export class ChromeFields extends React.Component {
         h: data.h || this.props.hsl.h,
         s: Number(!isUndefined(data.s) ? data.s : this.props.hsl.s),
         l: Number(!isUndefined(data.l) ? data.l : this.props.hsl.l),
+        a: data.a || this.props.hsl.a,
         source: 'hsl',
       }, e)
     }


### PR DESCRIPTION
Fixes #886 
In the `ChromeFields.js` file, the `alpha` property was not handled properly in the `handleChange` function.